### PR TITLE
fix getBasicEllipsePoints so it compiles on Linux

### DIFF
--- a/Source/cg_Trajectory.cpp
+++ b/Source/cg_Trajectory.cpp
@@ -218,7 +218,8 @@ juce::Array<juce::Point<float>> Trajectory::getBasicCirclePoints()
 juce::Array<juce::Point<float>> Trajectory::getBasicEllipsePoints()
 {
     // just squish a circle!
-    juce::Array<juce::Point<float>> result{ getBasicCirclePoints() };
+    juce::Array<juce::Point<float>> result{};
+    result = getBasicCirclePoints();
     for (auto & point : result) {
         point.setY(point.getY() * 0.5f);
     }


### PR DESCRIPTION
Fixed an old bug on Linux, it should also work on other platforms.