### PR TITLE
Standalone build with higher number of sources

### DIFF
--- a/.github/workflows/ControlGris-builds.yml
+++ b/.github/workflows/ControlGris-builds.yml
@@ -11,10 +11,10 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v2
 
-      - name: download JUCE
+      - name: Download JUCE
         run: curl -L https://github.com/juce-framework/JUCE/releases/download/7.0.1/juce-7.0.1-linux.zip --output JUCE.zip
 
-      - name: unpack JUCE
+      - name: Unpack JUCE
         run: unzip JUCE.zip
 
       - name: Install dependencies
@@ -24,17 +24,24 @@ jobs:
             libfreetype6-dev libx11-dev libxcomposite-dev libxcursor-dev libxinerama-dev libxrandr-dev \
             mesa-common-dev libjack-dev
 
-      - name: set global JUCE search paths
+      - name: Set global JUCE search paths
         run: JUCE/Projucer --set-global-search-path linux defaultJuceModulePath /home/runner/work/ControlGris/ControlGris/JUCE/modules
 
-      - name: generate makefile
-        run: cd JUCE && ./Projucer --resave ../ControlGris.jucer
+      - name: Generate makefile (Standalone & VST3 only)
+        run: |
+          cd JUCE
+          ./Projucer --resave ../ControlGris.jucer --set-exporter LinuxMakefile --set-config Release \
+            --set-enabled-targets Standalone,VST3
 
-      - name: Compile ControlGris
-        run: cd Builds/LinuxMakefile && make CXX=clang++-10 CONFIG=Release -j8
+      - name: Compile ControlGris (Standalone & VST3 only)
+        run: |
+          cd Builds/LinuxMakefile
+          make CXX=clang++-10 CONFIG=Release -j8 ControlGris_Standalone ControlGris_VST3
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
           name: ControlGris-Build
-          path: Builds/LinuxMakefile/build/*
+          path: |
+            Builds/LinuxMakefile/build/ControlGris_Standalone
+            Builds/LinuxMakefile/build/ControlGris_VST3

--- a/.github/workflows/ControlGris-builds.yml
+++ b/.github/workflows/ControlGris-builds.yml
@@ -1,4 +1,4 @@
-name: ControlGRIS Linux build 
+name: ControlGris Linux build
 on:
   push:
     branches: ['*']
@@ -25,16 +25,16 @@ jobs:
             mesa-common-dev libjack-dev
 
       - name: set global JUCE search paths
-        run: JUCE/Projucer --set-global-search-path linux defaultJuceModulePath /home/runner/work/ControlGRIS/ControlGRIS/JUCE/modules
+        run: JUCE/Projucer --set-global-search-path linux defaultJuceModulePath /home/runner/work/ControlGris/ControlGris/JUCE/modules
 
       - name: generate makefile
         run: cd JUCE && ./Projucer --resave ../ControlGris.jucer
 
-      - name: Compile ControlGRIS
+      - name: Compile ControlGris
         run: cd Builds/LinuxMakefile && make CXX=clang++-10 CONFIG=Release -j 8
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: ControlGRIS-Build
+          name: ControlGris-Build
           path: Builds/LinuxMakefile/build/*

--- a/.github/workflows/ControlGris-builds.yml
+++ b/.github/workflows/ControlGris-builds.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout
 
       - name: download JUCE
         run: curl -L https://github.com/juce-framework/JUCE/releases/download/7.0.1/juce-7.0.1-linux.zip --output JUCE.zip
@@ -31,10 +31,10 @@ jobs:
         run: cd JUCE && ./Projucer --resave ../ControlGris.jucer
 
       - name: Compile ControlGris
-        run: cd Builds/LinuxMakefile && make CXX=clang++-10 CONFIG=Release -j 8
+        run: cd Builds/LinuxMakefile && make CXX=clang++-10 CONFIG=Release -j8
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact
         with:
           name: ControlGris-Build
           path: Builds/LinuxMakefile/build/*

--- a/.github/workflows/ControlGris-builds.yml
+++ b/.github/workflows/ControlGris-builds.yml
@@ -28,7 +28,7 @@ jobs:
         run: JUCE/Projucer --set-global-search-path linux defaultJuceModulePath /home/runner/work/ControlGRIS/ControlGRIS/JUCE/modules
 
       - name: generate makefile
-        run: cd JUCE && ./Projucer --resave ../ControlGRIS.jucer
+        run: cd JUCE && ./Projucer --resave ../ControlGris.jucer
 
       - name: Compile ControlGRIS
         run: cd Builds/LinuxMakefile && make CXX=clang++-10 CONFIG=Release -j 8

--- a/.github/workflows/ControlGris-builds.yml
+++ b/.github/workflows/ControlGris-builds.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   Build-Ubuntu-20-04:
     runs-on: ubuntu-20.04
+    if: github.event_name == 'push' && github.event.pull_request == null || github.event_name == 'pull_request'
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2

--- a/.github/workflows/ControlGris-builds.yml
+++ b/.github/workflows/ControlGris-builds.yml
@@ -17,10 +17,26 @@ jobs:
       - name: Unpack JUCE
         run: unzip JUCE.zip
 
+      - name: Install latest Clang
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y wget lsb-release software-properties-common
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 18
+          sudo apt-get install -y clang-18
+
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y clang-10 ladspa-sdk freeglut3-dev libasound2-dev libcurl4-openssl-dev \
+          sudo apt-get install -y ladspa-sdk freeglut3-dev libasound2-dev libcurl4-openssl-dev \
+            libfreetype6-dev libx11-dev libxcomposite-dev libxcursor-dev libxinerama-dev libxrandr-dev \
+            mesa-common-dev libjack-dev
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-18 ladspa-sdk freeglut3-dev libasound2-dev libcurl4-openssl-dev \
             libfreetype6-dev libx11-dev libxcomposite-dev libxcursor-dev libxinerama-dev libxrandr-dev \
             mesa-common-dev libjack-dev
 
@@ -36,7 +52,7 @@ jobs:
       - name: Compile ControlGris (Standalone & VST3 only)
         run: |
           cd Builds/LinuxMakefile
-          make CXX=clang++-10 CONFIG=Release -j8 ControlGris_Standalone ControlGris_VST3
+          make CXX=clang++-18 CONFIG=Release -j8 ControlGris_Standalone ControlGris_VST3
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ControlGris-builds.yml
+++ b/.github/workflows/ControlGris-builds.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check out repository code
-        uses: actions/checkout
+        uses: actions/checkout@v2
 
       - name: download JUCE
         run: curl -L https://github.com/juce-framework/JUCE/releases/download/7.0.1/juce-7.0.1-linux.zip --output JUCE.zip
@@ -34,7 +34,7 @@ jobs:
         run: cd Builds/LinuxMakefile && make CXX=clang++-10 CONFIG=Release -j8
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact
+        uses: actions/upload-artifact@v4
         with:
           name: ControlGris-Build
           path: Builds/LinuxMakefile/build/*

--- a/.github/workflows/ControlGris-builds.yml
+++ b/.github/workflows/ControlGris-builds.yml
@@ -4,6 +4,7 @@ on:
     branches: ['*']
   pull_request:
     branches: ['*']
+    types: [opened, synchronize]
 jobs:
   Build-Ubuntu-20-04:
     runs-on: ubuntu-20.04
@@ -52,7 +53,7 @@ jobs:
       - name: Compile ControlGris (Standalone & VST3 only)
         run: |
           cd Builds/LinuxMakefile
-          make CXX=clang++-18 CONFIG=Release -j8 ControlGris_Standalone ControlGris_VST3
+          make CXX=clang++-18 CONFIG=Release -j8 Standalone VST3
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ControlGris-builds.yml
+++ b/.github/workflows/ControlGris-builds.yml
@@ -58,6 +58,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ControlGris-Build
-          path: |
-            Builds/LinuxMakefile/build/ControlGris_Standalone
-            Builds/LinuxMakefile/build/ControlGris_VST3
+          path: Builds/LinuxMakefile/build/*

--- a/.github/workflows/ControlGris-builds.yml
+++ b/.github/workflows/ControlGris-builds.yml
@@ -1,0 +1,40 @@
+name: ControlGRIS Linux build 
+on:
+  push:
+    branches: ['*']
+  pull_request:
+    branches: ['*']
+jobs:
+  Build-Ubuntu-20-04:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+
+      - name: download JUCE
+        run: curl -L https://github.com/juce-framework/JUCE/releases/download/7.0.1/juce-7.0.1-linux.zip --output JUCE.zip
+
+      - name: unpack JUCE
+        run: unzip JUCE.zip
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-10 ladspa-sdk freeglut3-dev libasound2-dev libcurl4-openssl-dev \
+            libfreetype6-dev libx11-dev libxcomposite-dev libxcursor-dev libxinerama-dev libxrandr-dev \
+            mesa-common-dev libjack-dev
+
+      - name: set global JUCE search paths
+        run: JUCE/Projucer --set-global-search-path linux defaultJuceModulePath /home/runner/work/ControlGRIS/ControlGRIS/JUCE/modules
+
+      - name: generate makefile
+        run: cd JUCE && ./Projucer --resave ../ControlGRIS.jucer
+
+      - name: Compile ControlGRIS
+        run: cd Builds/LinuxMakefile && make CXX=clang++-10 CONFIG=Release -j 8
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: ControlGRIS-Build
+          path: Builds/LinuxMakefile/build/*

--- a/.github/workflows/ControlGris-builds.yml
+++ b/.github/workflows/ControlGris-builds.yml
@@ -4,11 +4,9 @@ on:
     branches: ['*']
   pull_request:
     branches: ['*']
-    types: [opened, synchronize]
 jobs:
   Build-Ubuntu-20-04:
     runs-on: ubuntu-20.04
-    if: github.event_name == 'push' && github.event.pull_request == null || github.event_name == 'pull_request'
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2

--- a/ControlGris.jucer
+++ b/ControlGris.jucer
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<JUCERPROJECT id="m50y5Z" name="ControlGris" projectType="audioplug" pluginFormats="buildAU,buildStandalone,buildVST3"
+<JUCERPROJECT id="m50y5Z" name="ControlGris" projectType="audioplug" pluginFormats="buildAAX,buildAU,buildStandalone,buildVST,buildVST3"
               version="1.4.5" bundleIdentifier="com.gris.umontreal.controlgris"
               companyName="UdeM" aaxIdentifier="com.udem.GRIS.ControlGris"
               pluginManufacturer="UdeM" pluginManufacturerCode="UdeM" pluginCode="Xzz1"
@@ -202,10 +202,8 @@
     </LINUX_MAKE>
     <VS2022 targetFolder="Builds/VisualStudio2022">
       <CONFIGURATIONS>
-        <CONFIGURATION isDebug="1" name="Debug" enablePluginBinaryCopyStep="1" headerPath="C:\SDKs\asiosdk_2.3.3_2019-06-14\common"
-                       vst3BinaryLocation="C:\Program Files\Common Files\VST3"/>
-        <CONFIGURATION isDebug="0" name="Release" headerPath="C:\SDKs\asiosdk_2.3.3_2019-06-14\common"
-                       enablePluginBinaryCopyStep="1" vst3BinaryLocation="C:\Program Files\Common Files\VST3"/>
+        <CONFIGURATION isDebug="1" name="Debug" enablePluginBinaryCopyStep="1" vst3BinaryLocation="C:\Program Files\Common Files\VST3"/>
+        <CONFIGURATION isDebug="0" name="Release" enablePluginBinaryCopyStep="1" vst3BinaryLocation="C:\Program Files\Common Files\VST3"/>
       </CONFIGURATIONS>
       <MODULEPATHS>
         <MODULEPATH id="juce_audio_basics"/>

--- a/ControlGris.jucer
+++ b/ControlGris.jucer
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<JUCERPROJECT id="m50y5Z" name="ControlGris" projectType="audioplug" pluginFormats="buildAU,buildVST3"
+<JUCERPROJECT id="m50y5Z" name="ControlGris" projectType="audioplug" pluginFormats="buildAU,buildStandalone,buildVST3"
               version="1.4.5" bundleIdentifier="com.gris.umontreal.controlgris"
               companyName="UdeM" aaxIdentifier="com.udem.GRIS.ControlGris"
               pluginManufacturer="UdeM" pluginManufacturerCode="UdeM" pluginCode="Xzz1"

--- a/ControlGris.jucer
+++ b/ControlGris.jucer
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<JUCERPROJECT id="m50y5Z" name="ControlGris" projectType="audioplug" pluginFormats="buildAAX,buildAU,buildVST,buildVST3"
+<JUCERPROJECT id="m50y5Z" name="ControlGris" projectType="audioplug" pluginFormats="buildAU,buildVST3"
               version="1.4.5" bundleIdentifier="com.gris.umontreal.controlgris"
               companyName="UdeM" aaxIdentifier="com.udem.GRIS.ControlGris"
               pluginManufacturer="UdeM" pluginManufacturerCode="UdeM" pluginCode="Xzz1"
@@ -200,31 +200,10 @@
         <MODULEPATH id="juce_audio_devices" path="../../../../../dev/JUCE/modules"/>
       </MODULEPATHS>
     </LINUX_MAKE>
-    <VS2019 targetFolder="Builds/VisualStudio2019">
-      <CONFIGURATIONS>
-        <CONFIGURATION isDebug="1" name="Debug"/>
-        <CONFIGURATION isDebug="0" name="Release"/>
-      </CONFIGURATIONS>
-      <MODULEPATHS>
-        <MODULEPATH id="juce_osc"/>
-        <MODULEPATH id="juce_gui_extra"/>
-        <MODULEPATH id="juce_gui_basics"/>
-        <MODULEPATH id="juce_graphics"/>
-        <MODULEPATH id="juce_events"/>
-        <MODULEPATH id="juce_data_structures"/>
-        <MODULEPATH id="juce_core"/>
-        <MODULEPATH id="juce_audio_processors"/>
-        <MODULEPATH id="juce_audio_plugin_client"/>
-        <MODULEPATH id="juce_audio_basics"/>
-        <MODULEPATH id="juce_audio_utils"/>
-        <MODULEPATH id="juce_audio_formats"/>
-        <MODULEPATH id="juce_audio_devices"/>
-      </MODULEPATHS>
-    </VS2019>
     <VS2022 targetFolder="Builds/VisualStudio2022">
       <CONFIGURATIONS>
-        <CONFIGURATION isDebug="1" name="Debug" enablePluginBinaryCopyStep="0"/>
-        <CONFIGURATION isDebug="0" name="Release"/>
+        <CONFIGURATION isDebug="1" name="Debug" enablePluginBinaryCopyStep="0" headerPath="C:\SDKs\asiosdk_2.3.3_2019-06-14\common"/>
+        <CONFIGURATION isDebug="0" name="Release" headerPath="C:\SDKs\asiosdk_2.3.3_2019-06-14\common"/>
       </CONFIGURATIONS>
       <MODULEPATHS>
         <MODULEPATH id="juce_audio_basics"/>

--- a/ControlGris.jucer
+++ b/ControlGris.jucer
@@ -202,8 +202,10 @@
     </LINUX_MAKE>
     <VS2022 targetFolder="Builds/VisualStudio2022">
       <CONFIGURATIONS>
-        <CONFIGURATION isDebug="1" name="Debug" enablePluginBinaryCopyStep="0" headerPath="C:\SDKs\asiosdk_2.3.3_2019-06-14\common"/>
-        <CONFIGURATION isDebug="0" name="Release" headerPath="C:\SDKs\asiosdk_2.3.3_2019-06-14\common"/>
+        <CONFIGURATION isDebug="1" name="Debug" enablePluginBinaryCopyStep="1" headerPath="C:\SDKs\asiosdk_2.3.3_2019-06-14\common"
+                       vst3BinaryLocation="C:\Program Files\Common Files\VST3"/>
+        <CONFIGURATION isDebug="0" name="Release" headerPath="C:\SDKs\asiosdk_2.3.3_2019-06-14\common"
+                       enablePluginBinaryCopyStep="1" vst3BinaryLocation="C:\Program Files\Common Files\VST3"/>
       </CONFIGURATIONS>
       <MODULEPATHS>
         <MODULEPATH id="juce_audio_basics"/>

--- a/Source/.clang-format
+++ b/Source/.clang-format
@@ -49,7 +49,6 @@ BreakConstructorInitializersBeforeComma: true
 BreakConstructorInitializers: BeforeComma
 BreakAfterJavaFieldAnnotations: false
 BreakStringLiterals: true
-ColumnLimit:     120
 CommentPragmas:  '^ IWYU pragma:'
 CompactNamespaces: false
 ConstructorInitializerAllOnOneLineOrOnePerLine: true

--- a/Source/.clang-format
+++ b/Source/.clang-format
@@ -49,7 +49,7 @@ BreakConstructorInitializersBeforeComma: true
 BreakConstructorInitializers: BeforeComma
 BreakAfterJavaFieldAnnotations: false
 BreakStringLiterals: true
-ColumnLimit:     1200
+ColumnLimit:     120
 CommentPragmas:  '^ IWYU pragma:'
 CompactNamespaces: false
 ConstructorInitializerAllOnOneLineOrOnePerLine: true

--- a/Source/.clang-format
+++ b/Source/.clang-format
@@ -49,6 +49,7 @@ BreakConstructorInitializersBeforeComma: true
 BreakConstructorInitializers: BeforeComma
 BreakAfterJavaFieldAnnotations: false
 BreakStringLiterals: true
+ColumnLimit:     1200
 CommentPragmas:  '^ IWYU pragma:'
 CompactNamespaces: false
 ConstructorInitializerAllOnOneLineOrOnePerLine: true

--- a/Source/cg_ControlGrisAudioProcessor.cpp
+++ b/Source/cg_ControlGrisAudioProcessor.cpp
@@ -87,8 +87,7 @@ juce::AudioProcessorValueTreeState::ParameterLayout createParameterLayout()
 }
 
 //==============================================================================
-ControlGrisAudioProcessor::ControlGrisAudioProcessor()
-    :
+ControlGrisAudioProcessor::ControlGrisAudioProcessor() :
 #ifndef JucePlugin_PreferredChannelConfigurations
     AudioProcessor(BusesProperties()
     #if !JucePlugin_IsMidiEffect
@@ -145,7 +144,7 @@ ControlGrisAudioProcessor::ControlGrisAudioProcessor()
     // Per source mAudioProcessorValueTreeState. Because there is no attachment to the automatable
     // mAudioProcessorValueTreeState, we need to keep track of the current parameter values to be
     // able to reload the last state of the plugin when we close/open the UI.
-    for (int i{}; i < MAX_NUMBER_OF_SOURCES; ++i) {
+    for (int i{}; i < mSources.MAX_NUMBER_OF_SOURCES; ++i) {
         juce::String oscId(i);
         // Non-automatable, per source, mAudioProcessorValueTreeState.
         mAudioProcessorValueTreeState.state.setProperty(juce::String("p_azimuth_") + oscId,
@@ -291,7 +290,7 @@ void ControlGrisAudioProcessor::setSpatMode(SpatMode const spatMode)
 {
     mSpatMode = spatMode;
     mAudioProcessorValueTreeState.state.setProperty("oscFormat", static_cast<int>(mSpatMode), nullptr);
-    for (int i{}; i < MAX_NUMBER_OF_SOURCES; ++i) {
+    for (int i{}; i < mSources.MAX_NUMBER_OF_SOURCES; ++i) {
         mSources.get(i).setSpatMode(spatMode);
     }
 
@@ -332,7 +331,7 @@ void ControlGrisAudioProcessor::setFirstSourceId(SourceId const firstSourceId, b
 {
     mFirstSourceId = firstSourceId;
     mAudioProcessorValueTreeState.state.setProperty("firstSourceId", mFirstSourceId.get(), nullptr);
-    for (int i{}; i < MAX_NUMBER_OF_SOURCES; ++i) {
+    for (int i{}; i < mSources.MAX_NUMBER_OF_SOURCES; ++i) {
         mSources.get(i).setId(SourceId{ i + mFirstSourceId.get() });
     }
 
@@ -1150,7 +1149,7 @@ juce::AudioProcessorEditor * ControlGrisAudioProcessor::createEditor()
 //==============================================================================
 void ControlGrisAudioProcessor::getStateInformation(juce::MemoryBlock & destData)
 {
-    for (int sourceIndex{}; sourceIndex < MAX_NUMBER_OF_SOURCES; ++sourceIndex) {
+    for (int sourceIndex{}; sourceIndex < mSources.MAX_NUMBER_OF_SOURCES; ++sourceIndex) {
         juce::String const id{ sourceIndex };
         juce::Identifier const azimuthId{ juce::String{ "p_azimuth_" } + id };
         juce::Identifier const elevationId{ juce::String{ "p_elevation_" } + id };
@@ -1215,7 +1214,7 @@ void ControlGrisAudioProcessor::setStateInformation(void const * data, int const
         }
 
         // Load stored sources positions
-        for (int sourceIndex{}; sourceIndex < MAX_NUMBER_OF_SOURCES; ++sourceIndex) {
+        for (int sourceIndex{}; sourceIndex < mSources.MAX_NUMBER_OF_SOURCES; ++sourceIndex) {
             juce::String const id{ sourceIndex };
             juce::Identifier const azimuthId{ juce::String{ "p_azimuth_" } + id };
             juce::Identifier const elevationId{ juce::String{ "p_elevation_" } + id };

--- a/Source/cg_ControlGrisAudioProcessor.cpp
+++ b/Source/cg_ControlGrisAudioProcessor.cpp
@@ -87,7 +87,8 @@ juce::AudioProcessorValueTreeState::ParameterLayout createParameterLayout()
 }
 
 //==============================================================================
-ControlGrisAudioProcessor::ControlGrisAudioProcessor() :
+ControlGrisAudioProcessor::ControlGrisAudioProcessor()
+    :
 #ifndef JucePlugin_PreferredChannelConfigurations
     AudioProcessor(BusesProperties()
     #if !JucePlugin_IsMidiEffect

--- a/Source/cg_ControlGrisAudioProcessor.cpp
+++ b/Source/cg_ControlGrisAudioProcessor.cpp
@@ -103,6 +103,11 @@ ControlGrisAudioProcessor::ControlGrisAudioProcessor()
     mAudioProcessorValueTreeState(*this, nullptr, juce::Identifier(JucePlugin_Name), createParameterLayout())
 
 {
+#if JUCE_DEBUG
+    juce::UnitTestRunner testRunner;
+    testRunner.runAllTests();
+#endif
+
     setLatencySamples(0);
 
     // Size of the plugin window.

--- a/Source/cg_ControlGrisAudioProcessorEditor.cpp
+++ b/Source/cg_ControlGrisAudioProcessorEditor.cpp
@@ -430,14 +430,18 @@ void ControlGrisAudioProcessorEditor::sourcesPlacementChangedCallback(SourcePlac
     auto const cachedSourceLink{ mPositionTrajectoryManager.getSourceLink() };
     mProcessor.setPositionSourceLink(PositionSourceLink::independent, SourceLinkEnforcer::OriginOfChange::automation);
 
-    auto const numOfSources = mProcessor.getSources().size();
-    auto const increment = 360.0f / numOfSources;
+    auto const isCubeMode{ mProcessor.getSpatMode() == SpatMode::cube };
+    auto const distance{ isCubeMode ? 0.7f : 1.0f };
+    auto const numOfSources{mProcessor.getSources().size()};
+    auto const increment{360.0f / numOfSources};
     auto curOddAzimuth{ 0.0f + increment / 2 };
     auto curEvenAzimuth{ 360.0f - increment / 2 };
+
     auto const getAzimuthValue = [sourcePlacement, numOfSources, increment, &curOddAzimuth, &curEvenAzimuth](int const sourceIndex) {
         switch (sourcePlacement) {
         case SourcePlacement::leftAlternate:
             if (sourceIndex % 2 == 0) {
+                // TODO VB: get rid of these temp values
                 auto const temp{ curEvenAzimuth };
                 curEvenAzimuth -= increment;
                 return temp;
@@ -474,9 +478,6 @@ void ControlGrisAudioProcessorEditor::sourcesPlacementChangedCallback(SourcePlac
             return 0.f;
         }
     };
-
-    auto const isCubeMode{ mProcessor.getSpatMode() == SpatMode::cube };
-    auto const distance{ isCubeMode ? 0.7f : 1.0f };
 
     for (auto i = 0; i < numOfSources; ++i) {
         auto & source{ mProcessor.getSources()[i] };

--- a/Source/cg_ControlGrisAudioProcessorEditor.cpp
+++ b/Source/cg_ControlGrisAudioProcessorEditor.cpp
@@ -431,7 +431,7 @@ void ControlGrisAudioProcessorEditor::sourcesPlacementChangedCallback(SourcePlac
     mProcessor.setPositionSourceLink(PositionSourceLink::independent, SourceLinkEnforcer::OriginOfChange::automation);
 
     auto const numOfSources = mProcessor.getSources().size();
-    if (numOfSources <= 8)
+    if (false /*numOfSources <= 8*/)
     {
         auto const getAzimuthValue = [sourcePlacement, numOfSources](int const sourceIndex) {
             auto const offset{ Degrees{ 360.0f } / static_cast<float>(numOfSources) / 2.0f };
@@ -494,20 +494,27 @@ void ControlGrisAudioProcessorEditor::sourcesPlacementChangedCallback(SourcePlac
     }
     else
     {
-        auto const increment = Degrees{ 360.0f } / static_cast<float>(numOfSources);
-        Degrees curAzimuth{ 0.0f };
+        auto const increment =  360.0f / numOfSources;
+        auto curEvenAzimuth{ 0.0f + increment/2 };
+        auto curOddAzimuth{ 360.0f - increment / 2 };
 
-        for (auto & source : mProcessor.getSources()) {
+        int i = -1;
+        for (auto & source : mProcessor.getSources())
+        {
             auto const isCubeMode{ mProcessor.getSpatMode() == SpatMode::cube };
             auto const elevation{ isCubeMode ? source.getElevation() : MAX_ELEVATION };
             auto const distance{ isCubeMode ? 0.7f : 1.0f };
 
-            source.setCoordinates(curAzimuth,
-                                  elevation,
-                                  distance,
-                                  Source::OriginOfChange::userAnchorMove);
-
-            curAzimuth += increment;
+            if (++i % 2 == 0)
+            {
+                source.setCoordinates(Degrees (curEvenAzimuth), elevation, distance, Source::OriginOfChange::userAnchorMove);
+                curEvenAzimuth += increment;
+            }
+            else
+            {
+                source.setCoordinates(Degrees (curOddAzimuth), elevation, distance, Source::OriginOfChange::userAnchorMove);
+                curOddAzimuth -= increment;
+            }
         }
     }
 

--- a/Source/cg_ControlGrisAudioProcessorEditor.cpp
+++ b/Source/cg_ControlGrisAudioProcessorEditor.cpp
@@ -464,28 +464,26 @@ void ControlGrisAudioProcessorEditor::sourcesPlacementChangedCallback(SourcePlac
         }
     };
 
+    //position all sources
     for (auto i = 0; i < numOfSources; ++i) {
         auto & source{ mProcessor.getSources()[i] };
         auto const elevation{ isCubeMode ? source.getElevation() : MAX_ELEVATION };
-        source.setCoordinates(Degrees{ getAzimuthValue(i) }, elevation, distance, Source::OriginOfChange::userAnchorMove);
+        auto const azimuth{Degrees{ getAzimuthValue(i) }};
+        source.setCoordinates(azimuth, elevation, distance, Source::OriginOfChange::userAnchorMove);
     }
 
+    // TODO: why are we storing the _normalized_ positions in the processor?
+    //then as a second pass, give the processor the normalized positions
     for (SourceIndex i{}; i < SourceIndex{ numOfSources }; ++i) {
-        mProcessor.setSourceParameterValue(i,
-                                           SourceParameter::azimuth,
-                                           mProcessor.getSources()[i].getNormalizedAzimuth().get());
-        mProcessor.setSourceParameterValue(i,
-                                           SourceParameter::elevation,
-                                           mProcessor.getSources()[i].getNormalizedElevation().get());
-        mProcessor.setSourceParameterValue(i, SourceParameter::distance, mProcessor.getSources()[i].getDistance());
+        auto const & source{ mProcessor.getSources()[i] };
+        mProcessor.setSourceParameterValue(i, SourceParameter::azimuth, source.getNormalizedAzimuth().get());
+        mProcessor.setSourceParameterValue(i, SourceParameter::elevation, source.getNormalizedElevation().get());
+        mProcessor.setSourceParameterValue(i, SourceParameter::distance, source.getDistance());
     }
 
-    mSectionSourcePosition.updateSelectedSource(&mProcessor.getSources()[mSelectedSource],
-                                                SourceIndex{},
-                                                mProcessor.getSpatMode());
-
-    mPositionTrajectoryManager.setTrajectoryType(mPositionTrajectoryManager.getTrajectoryType(),
-                                                 mProcessor.getSources().getPrimarySource().getPos());
+    // update selected source
+    mSectionSourcePosition.updateSelectedSource(&mProcessor.getSources()[mSelectedSource], SourceIndex{}, mProcessor.getSpatMode());
+    mPositionTrajectoryManager.setTrajectoryType(mPositionTrajectoryManager.getTrajectoryType(), mProcessor.getSources().getPrimarySource().getPos());
 
     //set source link back to its cached value
     mProcessor.setPositionSourceLink(cachedSourceLink, SourceLinkEnforcer::OriginOfChange::automation);

--- a/Source/cg_ControlGrisAudioProcessorEditor.cpp
+++ b/Source/cg_ControlGrisAudioProcessorEditor.cpp
@@ -440,26 +440,11 @@ void ControlGrisAudioProcessorEditor::sourcesPlacementChangedCallback(SourcePlac
     auto const getAzimuthValue = [sourcePlacement, numOfSources, increment, &curOddAzimuth, &curEvenAzimuth](int const sourceIndex) {
         switch (sourcePlacement) {
         case SourcePlacement::leftAlternate:
-            if (sourceIndex % 2 == 0) {
-                // TODO VB: get rid of these temp values
-                auto const temp{ curEvenAzimuth };
-                curEvenAzimuth -= increment;
-                return temp;
-            } else {
-                auto const temp{ curOddAzimuth };
-                curOddAzimuth += increment;
-                return temp;
-            }
+            return (sourceIndex % 2 == 0) ? std::exchange(curEvenAzimuth, curEvenAzimuth - increment)
+                                          : std::exchange(curOddAzimuth, curOddAzimuth + increment);
         case SourcePlacement::rightAlternate:
-            if (sourceIndex % 2 == 0) {
-                auto const temp{ curOddAzimuth };
-                curOddAzimuth += increment;
-                return temp;
-            } else {
-                auto const temp{ curEvenAzimuth };
-                curEvenAzimuth -= increment;
-                return temp;
-            }
+            return (sourceIndex % 2 == 0) ? std::exchange(curOddAzimuth, curOddAzimuth + increment)
+                                          : std::exchange(curEvenAzimuth, curEvenAzimuth - increment);
         case SourcePlacement::leftClockwise:
             return 360.0f / numOfSources * sourceIndex - increment / 2;
         case SourcePlacement::leftCounterClockwise:

--- a/Source/cg_ControlGrisAudioProcessorEditor.cpp
+++ b/Source/cg_ControlGrisAudioProcessorEditor.cpp
@@ -431,24 +431,135 @@ void ControlGrisAudioProcessorEditor::sourcesPlacementChangedCallback(SourcePlac
     mProcessor.setPositionSourceLink(PositionSourceLink::independent, SourceLinkEnforcer::OriginOfChange::automation);
 
     auto const numOfSources = mProcessor.getSources().size();
+    if (numOfSources <= 8) {
+        auto const getAzimuthValue = [sourcePlacement, numOfSources](int const sourceIndex) {
+            auto const offset{ Degrees{ 360.0f } / static_cast<float>(numOfSources) / 2.0f };
+            auto const azimuths = [numOfSources]() {
+                const std::vector<Degrees> azims2{ Degrees{ -90.0f }, Degrees{ 90.0f } };
+                const std::vector<Degrees> azims4{ Degrees{ -45.0f }, Degrees{ 45.0f }, Degrees{ -135.0f }, Degrees{ 135.0f } };
+                const std::vector<Degrees> azims6{ Degrees{ -30.0f }, Degrees{ 30.0f },   Degrees{ -90.0f }, Degrees{ 90.0f },  Degrees{ -150.0f }, Degrees{ 150.0f } };
+                const std::vector<Degrees> azims8{ Degrees{ -22.5f },  Degrees{ 22.5f },   Degrees{ -67.5f }, Degrees{ 67.5f },   Degrees{ -112.5f }, Degrees{ 112.5f }, Degrees{ -157.5f }, Degrees{ 157.5f } };
+                if (numOfSources <= 2) {
+                    return azims2;
+                }
+                if (numOfSources <= 4) {
+                    return azims4;
+                }
+                if (numOfSources <= 6) {
+                    return azims6;
+                }
+                jassert(numOfSources <= 8);
+                return azims8;
+            }();
+            switch (sourcePlacement) {
+            case SourcePlacement::leftAlternate:
+                return azimuths[sourceIndex];
+            case SourcePlacement::rightAlternate:
+                return -azimuths[sourceIndex];
+            case SourcePlacement::leftClockwise:
+                return Degrees{ 360.0f } / static_cast<float>(numOfSources) * static_cast<float>(sourceIndex) - offset;
+            case SourcePlacement::leftCounterClockwise:
+                return Degrees{ 360.0f } / static_cast<float>(numOfSources) * static_cast<float>(-sourceIndex) - offset;
+            case SourcePlacement::rightClockwise:
+                return Degrees{ 360.0f } / static_cast<float>(numOfSources) * static_cast<float>(sourceIndex) + offset;
+            case SourcePlacement::rightCounterClockwise:
+                return Degrees{ 360.0f } / static_cast<float>(numOfSources) * static_cast<float>(-sourceIndex) + offset;
+            case SourcePlacement::topClockwise:
+                return Degrees{ 360.0f } / static_cast<float>(numOfSources) * static_cast<float>(sourceIndex);
+            case SourcePlacement::topCounterClockwise:
+                return Degrees{ 360.0f } / static_cast<float>(numOfSources) * static_cast<float>(-sourceIndex);
+            case SourcePlacement::undefined:
+            default:
+                jassertfalse;
+            }
+            return Degrees{};
+        };
 
-    auto const increment = 360.0f / numOfSources;
-    auto curOddAzimuth{ 0.0f + increment / 2 };
-    auto curEvenAzimuth{ 360.0f - increment / 2 };
+        // position sources, iterating backwards
+        for (auto sourceIndex{ numOfSources - 1 }; sourceIndex >= 0; --sourceIndex) {
+            auto & source{ mProcessor.getSources()[sourceIndex] };
+            auto const isCubeMode{ mProcessor.getSpatMode() == SpatMode::cube };
+            auto const elevation{ isCubeMode ? source.getElevation() : MAX_ELEVATION };
+            auto const distance{ isCubeMode ? 0.7f : 1.0f };
+            source.setCoordinates(getAzimuthValue(sourceIndex), elevation, distance, Source::OriginOfChange::userAnchorMove);
+        }
+    } else {
 
-    int i = -1;
-    for (auto & source : mProcessor.getSources()) {
+        auto const increment = 360.0f / numOfSources;
+        auto curOddAzimuth{ 0.0f + increment / 2 };
+        auto curEvenAzimuth{ 360.0f - increment / 2 };
+#if 0
+        int i = -1;
+        // for (int i = 0; i < numOfSources; ++i) {
+        for (auto & source : mProcessor.getSources()) {
+            auto const isCubeMode{ mProcessor.getSpatMode() == SpatMode::cube };
+            auto const elevation{ isCubeMode ? source.getElevation() : MAX_ELEVATION };
+            auto const distance{ isCubeMode ? 0.7f : 1.0f };
+
+            if (++i % 2 == 0) {
+                source.setCoordinates(Degrees(curEvenAzimuth), elevation, distance, Source::OriginOfChange::userAnchorMove);
+                curEvenAzimuth -= increment;
+            } else {
+                source.setCoordinates(Degrees(curOddAzimuth), elevation, distance, Source::OriginOfChange::userAnchorMove);
+                curOddAzimuth += increment;
+            }
+        }
+#else
+        auto const getAzimuthValue = [sourcePlacement, numOfSources, increment, &curOddAzimuth, &curEvenAzimuth](int const sourceIndex) {
+            switch (sourcePlacement) {
+            case SourcePlacement::leftAlternate:
+                if (sourceIndex % 2 == 0)
+                {
+                    auto const temp { curEvenAzimuth };
+                    curEvenAzimuth -= increment;
+                    return temp;
+                }
+                else
+                {
+                    auto const temp{ curOddAzimuth };
+                    curOddAzimuth += increment;
+                    return temp;
+                }
+            case SourcePlacement::rightAlternate:
+                if (sourceIndex % 2 == 0) {
+                    auto const temp{ curOddAzimuth };
+                    curOddAzimuth += increment;
+                    return temp;
+                } else {
+                    auto const temp{ curEvenAzimuth };
+                    curEvenAzimuth -= increment;
+                    return temp;
+                }
+            case SourcePlacement::leftClockwise:
+                return 360.0f / numOfSources * sourceIndex - increment;
+            case SourcePlacement::leftCounterClockwise:
+                return 360.0f / numOfSources * -sourceIndex - increment;
+            case SourcePlacement::rightClockwise:
+                return 360.0f / numOfSources * sourceIndex + increment;
+            case SourcePlacement::rightCounterClockwise:
+                return 360.0f / numOfSources * -sourceIndex + increment;
+            case SourcePlacement::topClockwise:
+                return 360.0f / numOfSources * sourceIndex;
+            case SourcePlacement::topCounterClockwise:
+                return 360.0f / numOfSources * -sourceIndex;
+            case SourcePlacement::undefined:
+            default:
+                jassertfalse;
+                return 0.f;
+            }
+        };
+
         auto const isCubeMode{ mProcessor.getSpatMode() == SpatMode::cube };
-        auto const elevation{ isCubeMode ? source.getElevation() : MAX_ELEVATION };
         auto const distance{ isCubeMode ? 0.7f : 1.0f };
 
-        if (++i % 2 == 0) {
-            source.setCoordinates(Degrees(curEvenAzimuth), elevation, distance, Source::OriginOfChange::userAnchorMove);
-            curEvenAzimuth -= increment;
-        } else {
-            source.setCoordinates(Degrees(curOddAzimuth), elevation, distance, Source::OriginOfChange::userAnchorMove);
-            curOddAzimuth += increment;
+        // position sources, iterating backwards
+        for (auto i = 0; i < numOfSources; ++i)
+        {
+            auto & source{ mProcessor.getSources()[i] };
+            auto const elevation{ isCubeMode ? source.getElevation() : MAX_ELEVATION };
+            source.setCoordinates(Degrees {getAzimuthValue(i)}, elevation, distance, Source::OriginOfChange::userAnchorMove);
         }
+        #endif
     }
 
     // mProcessor.updatePrimarySourceParameters(Source::ChangeType::position);

--- a/Source/cg_FieldComponent.cpp
+++ b/Source/cg_FieldComponent.cpp
@@ -34,7 +34,7 @@ FieldComponent::FieldComponent(Sources & sources) noexcept : mSources(sources)
 //==============================================================================
 FieldComponent::~FieldComponent() noexcept
 {
-    for (SourceIndex i{}; i < SourceIndex{ MAX_NUMBER_OF_SOURCES }; ++i) {
+    for (SourceIndex i{}; i < SourceIndex{ mSources.MAX_NUMBER_OF_SOURCES }; ++i) {
         mSources[i].removeGuiListener(this);
     }
 }

--- a/Source/cg_LinkStrategies.cpp
+++ b/Source/cg_LinkStrategies.cpp
@@ -251,7 +251,7 @@ void CircularFixedAngle::computeParameters_implementation(Sources const & finalS
 
     // copy initialAngles
     std::vector<std::pair<Degrees, SourceIndex>> initialAngles{};
-    initialAngles.resize(MAX_NUMBER_OF_SOURCES);
+    initialAngles.resize(finalStates.MAX_NUMBER_OF_SOURCES);
     for (auto const & finalState : finalStates) {
         auto const sourceIndex{ finalState.getIndex() };
 
@@ -365,7 +365,7 @@ void CircularFullyFixed::computeParameters_implementation(Sources const & finalS
     if (!mOrderingInitialized) {
         // copy initialAngles
         std::vector<std::pair<Degrees, SourceIndex>> initialAngles{};
-        initialAngles.resize(MAX_NUMBER_OF_SOURCES);
+        initialAngles.resize(finalStates.MAX_NUMBER_OF_SOURCES);
         for (auto const & finalState : finalStates) {
             auto const sourceIndex{ finalState.getIndex() };
 

--- a/Source/cg_LinkStrategies.cpp
+++ b/Source/cg_LinkStrategies.cpp
@@ -215,6 +215,9 @@ SourceSnapshot
 void CircularFixedAngle::computeParameters_implementation(Sources const & finalStates,
                                                           SourcesSnapshots const & initialStates)
 {
+    mSecSourcesLengthRatio.resize(finalStates.MAX_NUMBER_OF_SOURCES);
+    mOrdering.resize(finalStates.MAX_NUMBER_OF_SOURCES);
+
     auto const & primarySourceInitialState{ initialStates.primary };
     auto const & primarySourceFinalState{ finalStates.getPrimarySource() };
 
@@ -351,6 +354,8 @@ void CircularFixedAngle::setSecSourcesLengthRatioInitialized()
 void CircularFullyFixed::computeParameters_implementation(Sources const & finalStates,
                                                           SourcesSnapshots const & initialStates)
 {
+    mOrdering.resize(finalStates.MAX_NUMBER_OF_SOURCES);
+
     auto const & primarySourceInitialState{ initialStates.primary };
     auto const & primarySourceFinalState{ finalStates.getPrimarySource() };
 

--- a/Source/cg_LinkStrategies.cpp
+++ b/Source/cg_LinkStrategies.cpp
@@ -253,8 +253,9 @@ void CircularFixedAngle::computeParameters_implementation(Sources const & finalS
     mRotation = mPrimarySourceFinalAngle - primarySourceInitialAngle;
 
     // copy initialAngles
-    std::vector<std::pair<Degrees, SourceIndex>> initialAngles{};
-    initialAngles.resize(finalStates.MAX_NUMBER_OF_SOURCES);
+    JUCE_ASSERT_MESSAGE_THREAD
+    auto initialAngles = std::vector<std::pair<Degrees, SourceIndex>>(finalStates.MAX_NUMBER_OF_SOURCES);
+
     for (auto const & finalState : finalStates) {
         auto const sourceIndex{ finalState.getIndex() };
 
@@ -369,8 +370,9 @@ void CircularFullyFixed::computeParameters_implementation(Sources const & finalS
 
     if (!mOrderingInitialized) {
         // copy initialAngles
-        std::vector<std::pair<Degrees, SourceIndex>> initialAngles{};
-        initialAngles.resize(finalStates.MAX_NUMBER_OF_SOURCES);
+        JUCE_ASSERT_MESSAGE_THREAD
+        auto initialAngles = std::vector<std::pair<Degrees, SourceIndex>>(finalStates.MAX_NUMBER_OF_SOURCES);
+
         for (auto const & finalState : finalStates) {
             auto const sourceIndex{ finalState.getIndex() };
 

--- a/Source/cg_LinkStrategies.cpp
+++ b/Source/cg_LinkStrategies.cpp
@@ -223,7 +223,7 @@ void CircularFixedAngle::computeParameters_implementation(Sources const & finalS
 
     // initialize distance ratios of secondary sources
     if (!mSecSourcesLengthRatioInitialized) {
-        mSecSourcesLengthRatio.fill(0.0f);
+        std::fill(mSecSourcesLengthRatio.begin(), mSecSourcesLengthRatio.end(), 0.f);
         for (auto const & finalState : finalStates) {
             auto const sourceIndex{ finalState.getIndex() };
             auto const primaryDistFromOrig{ primarySourceInitialState.position.getDistanceFromOrigin() };
@@ -250,7 +250,8 @@ void CircularFixedAngle::computeParameters_implementation(Sources const & finalS
     mRotation = mPrimarySourceFinalAngle - primarySourceInitialAngle;
 
     // copy initialAngles
-    std::array<std::pair<Degrees, SourceIndex>, MAX_NUMBER_OF_SOURCES> initialAngles{};
+    std::vector<std::pair<Degrees, SourceIndex>> initialAngles{};
+    initialAngles.resize(MAX_NUMBER_OF_SOURCES);
     for (auto const & finalState : finalStates) {
         auto const sourceIndex{ finalState.getIndex() };
 
@@ -329,13 +330,13 @@ SourceSnapshot
 }
 
 //==============================================================================
-std::array<float, MAX_NUMBER_OF_SOURCES> CircularFixedAngle::getSecSourcesLengthRatio()
+std::vector<float> CircularFixedAngle::getSecSourcesLengthRatio()
 {
     return mSecSourcesLengthRatio;
 }
 
 //==============================================================================
-void CircularFixedAngle::setSecSourcesLengthRatio(std::array<float, MAX_NUMBER_OF_SOURCES> & secSourcesLengthRatio)
+void CircularFixedAngle::setSecSourcesLengthRatio(std::vector<float> & secSourcesLengthRatio)
 {
     mSecSourcesLengthRatio = secSourcesLengthRatio;
 }
@@ -363,7 +364,8 @@ void CircularFullyFixed::computeParameters_implementation(Sources const & finalS
 
     if (!mOrderingInitialized) {
         // copy initialAngles
-        std::array<std::pair<Degrees, SourceIndex>, MAX_NUMBER_OF_SOURCES> initialAngles{};
+        std::vector<std::pair<Degrees, SourceIndex>> initialAngles{};
+        initialAngles.resize(MAX_NUMBER_OF_SOURCES);
         for (auto const & finalState : finalStates) {
             auto const sourceIndex{ finalState.getIndex() };
 
@@ -432,13 +434,13 @@ SourceSnapshot
 }
 
 //==============================================================================
-std::array<int, MAX_NUMBER_OF_SOURCES> CircularFullyFixed::getOrdering()
+std::vector<int> CircularFullyFixed::getOrdering()
 {
     return mOrdering;
 }
 
 //==============================================================================
-void CircularFullyFixed::setOrdering(std::array<int, MAX_NUMBER_OF_SOURCES> & ordering)
+void CircularFullyFixed::setOrdering(std::vector<int> & ordering)
 {
     mOrdering = ordering;
 }

--- a/Source/cg_LinkStrategies.hpp
+++ b/Source/cg_LinkStrategies.hpp
@@ -155,6 +155,7 @@ class CircularFixedAngle final : public Base
 public:
     CircularFixedAngle ()
     {
+        auto const MAX_NUMBER_OF_SOURCES { juce::JUCEApplicationBase::isStandaloneApp() ? 128 : 8};
         mSecSourcesLengthRatio.resize(MAX_NUMBER_OF_SOURCES);
         mOrdering.resize(MAX_NUMBER_OF_SOURCES);
     }
@@ -188,7 +189,8 @@ class CircularFullyFixed final : public Base
     //==============================================================================
 public:
     CircularFullyFixed()
-    { 
+    {
+        auto const MAX_NUMBER_OF_SOURCES { juce::JUCEApplicationBase::isStandaloneApp() ? 128 : 8};
         mOrdering.resize(MAX_NUMBER_OF_SOURCES);
     }
 

--- a/Source/cg_LinkStrategies.hpp
+++ b/Source/cg_LinkStrategies.hpp
@@ -139,9 +139,9 @@ class CircularFixedAngle final : public Base
     Radians mDeviationPerSource{};
     Radians mPrimarySourceFinalAngle{};
     Radians mRotation{};
-    std::array<float, MAX_NUMBER_OF_SOURCES> mSecSourcesLengthRatio{};
+    std::vector<float> mSecSourcesLengthRatio{};
     bool mSecSourcesLengthRatioInitialized{};
-    std::array<int, MAX_NUMBER_OF_SOURCES> mOrdering{};
+    std::vector<int> mOrdering{};
     //==============================================================================
     void computeParameters_implementation(Sources const & finalStates, SourcesSnapshots const & initialStates) override;
     void enforce_implementation(Sources & finalStates,
@@ -153,8 +153,14 @@ class CircularFixedAngle final : public Base
                                                          SourceIndex sourceIndex) const override;
     //==============================================================================
 public:
-    std::array<float, MAX_NUMBER_OF_SOURCES> getSecSourcesLengthRatio();
-    void setSecSourcesLengthRatio(std::array<float, MAX_NUMBER_OF_SOURCES> & secSourcesLengthRatio);
+    CircularFixedAngle ()
+    {
+        mSecSourcesLengthRatio.resize(MAX_NUMBER_OF_SOURCES);
+        mOrdering.resize(MAX_NUMBER_OF_SOURCES);
+    }
+
+    std::vector<float> getSecSourcesLengthRatio();
+    void setSecSourcesLengthRatio(std::vector<float> & secSourcesLengthRatio);
     void setSecSourcesLengthRatioInitialized();
     //==============================================================================
     JUCE_LEAK_DETECTOR(CircularFixedAngle)
@@ -168,7 +174,7 @@ class CircularFullyFixed final : public Base
     Radians mPrimarySourceFinalAngle{};
     Radians mRotation{};
     float mRadius{};
-    std::array<int, MAX_NUMBER_OF_SOURCES> mOrdering{};
+    std::vector<int> mOrdering{};
     bool mOrderingInitialized{};
     //==============================================================================
     void computeParameters_implementation(Sources const & finalStates, SourcesSnapshots const & initialStates) override;
@@ -181,8 +187,13 @@ class CircularFullyFixed final : public Base
                                                          SourceIndex sourceIndex) const override;
     //==============================================================================
 public:
-    std::array<int, MAX_NUMBER_OF_SOURCES> getOrdering();
-    void setOrdering(std::array<int, MAX_NUMBER_OF_SOURCES> & ordering);
+    CircularFullyFixed()
+    { 
+        mOrdering.resize(MAX_NUMBER_OF_SOURCES);
+    }
+
+    std::vector<int> getOrdering();
+    void setOrdering(std::vector<int> & ordering);
     void setOrderingInitialized();
     //==============================================================================
     JUCE_LEAK_DETECTOR(CircularFullyFixed)

--- a/Source/cg_LinkStrategies.hpp
+++ b/Source/cg_LinkStrategies.hpp
@@ -153,13 +153,6 @@ class CircularFixedAngle final : public Base
                                                          SourceIndex sourceIndex) const override;
     //==============================================================================
 public:
-    CircularFixedAngle ()
-    {
-        auto const MAX_NUMBER_OF_SOURCES { juce::JUCEApplicationBase::isStandaloneApp() ? 128 : 8};
-        mSecSourcesLengthRatio.resize(MAX_NUMBER_OF_SOURCES);
-        mOrdering.resize(MAX_NUMBER_OF_SOURCES);
-    }
-
     std::vector<float> getSecSourcesLengthRatio();
     void setSecSourcesLengthRatio(std::vector<float> & secSourcesLengthRatio);
     void setSecSourcesLengthRatioInitialized();
@@ -188,12 +181,6 @@ class CircularFullyFixed final : public Base
                                                          SourceIndex sourceIndex) const override;
     //==============================================================================
 public:
-    CircularFullyFixed()
-    {
-        auto const MAX_NUMBER_OF_SOURCES { juce::JUCEApplicationBase::isStandaloneApp() ? 128 : 8};
-        mOrdering.resize(MAX_NUMBER_OF_SOURCES);
-    }
-
     std::vector<int> getOrdering();
     void setOrdering(std::vector<int> & ordering);
     void setOrderingInitialized();

--- a/Source/cg_SectionGeneralSettings.cpp
+++ b/Source/cg_SectionGeneralSettings.cpp
@@ -211,7 +211,7 @@ SectionGeneralSettings::SectionGeneralSettings(GrisLookAndFeel & grisLookAndFeel
 
     mNumOfSourcesEditor.setExplicitFocusOrder(2);
     mNumOfSourcesEditor.setText("2");
-    auto const MAX_NUMBER_OF_SOURCES { juce::JUCEApplicationBase::isStandaloneApp() ? 128 : 8};
+    auto const MAX_NUMBER_OF_SOURCES { juce::JUCEApplicationBase::isStandaloneApp() ? 256 : 8};
     mNumOfSourcesEditor.setInputFilter(new NumberRangeInputFilter(1, MAX_NUMBER_OF_SOURCES), true);
     mNumOfSourcesEditor.onReturnKey = [this] { mOscFormatCombo.grabKeyboardFocus(); };
     mNumOfSourcesEditor.onFocusLost = [this] {

--- a/Source/cg_SectionGeneralSettings.cpp
+++ b/Source/cg_SectionGeneralSettings.cpp
@@ -83,7 +83,10 @@ SectionGeneralSettings::SectionGeneralSettings(GrisLookAndFeel & grisLookAndFeel
 
     mNumOfSourcesEditor.setExplicitFocusOrder(2);
     mNumOfSourcesEditor.setText("2");
-    mNumOfSourcesEditor.setInputRestrictions(1, "12345678");
+
+    if (! juce::JUCEApplication::getInstance()->isStandaloneApp())
+        mNumOfSourcesEditor.setInputRestrictions(1, "12345678");
+
     mNumOfSourcesEditor.onReturnKey = [this] { mOscFormatCombo.grabKeyboardFocus(); };
     mNumOfSourcesEditor.onFocusLost = [this] {
         if (!mNumOfSourcesEditor.isEmpty()) {

--- a/Source/cg_SectionGeneralSettings.cpp
+++ b/Source/cg_SectionGeneralSettings.cpp
@@ -23,6 +23,42 @@
 namespace gris
 {
 //==============================================================================
+/**
+ * @class NumberRangeInputFilter
+ * @brief A filter to restrict text input to a specified numeric range.
+ */
+class NumberRangeInputFilter : public juce::TextEditor::InputFilter
+{
+public:
+    NumberRangeInputFilter(int _minValue, int _maxValue) : minValue(_minValue), maxValue(_maxValue) {}
+
+    /**
+     * @brief Filters the new text input to ensure it falls within the specified range.
+     * @param editor The text editor where the input is being entered.
+     * @param newInput The new text input.
+     * @return The filtered text input.
+     */
+    juce::String filterNewText(juce::TextEditor & editor, const juce::String & newInput) override
+    {
+        const auto currentText{ editor.getText() };
+        const auto newText{ currentText + newInput };
+
+        if (newText.isEmpty())
+            return newText;
+
+        const auto value{ newText.getIntValue() };
+        if (value >= minValue && value <= maxValue)
+            return newInput;
+
+        return {};
+    }
+
+private:
+    int minValue;
+    int maxValue;
+};
+
+//==============================================================================
 SectionGeneralSettings::SectionGeneralSettings(GrisLookAndFeel & grisLookAndFeel) : mGrisLookAndFeel(grisLookAndFeel)
 {
     mOscFormatLabel.setText("Mode:", juce::NotificationType::dontSendNotification);
@@ -83,9 +119,7 @@ SectionGeneralSettings::SectionGeneralSettings(GrisLookAndFeel & grisLookAndFeel
 
     mNumOfSourcesEditor.setExplicitFocusOrder(2);
     mNumOfSourcesEditor.setText("2");
-
-    if (! juce::JUCEApplication::getInstance()->isStandaloneApp())
-        mNumOfSourcesEditor.setInputRestrictions(1, "12345678");
+    mNumOfSourcesEditor.setInputFilter(new NumberRangeInputFilter(1, gris::MAX_NUMBER_OF_SOURCES), true);
 
     mNumOfSourcesEditor.onReturnKey = [this] { mOscFormatCombo.grabKeyboardFocus(); };
     mNumOfSourcesEditor.onFocusLost = [this] {

--- a/Source/cg_SectionGeneralSettings.cpp
+++ b/Source/cg_SectionGeneralSettings.cpp
@@ -23,6 +23,8 @@
 namespace gris
 {
 //==============================================================================
+
+// TODO: handle negative values when _minValue is negative
 /**
  * @class NumberRangeInputFilter
  * @brief A filter to restrict text input to a specified numeric range.

--- a/Source/cg_SectionGeneralSettings.cpp
+++ b/Source/cg_SectionGeneralSettings.cpp
@@ -40,8 +40,12 @@ public:
      */
     juce::String filterNewText(juce::TextEditor & editor, const juce::String & newInput) override
     {
-        const auto currentText{ editor.getText() };
-        const auto newText{ currentText + newInput };
+        auto const currentText{ editor.getText() };
+        auto newText{ currentText + newInput };
+
+        auto const selectedRange { editor.getHighlightedRegion() };
+        if (! selectedRange.isEmpty())
+            newText = currentText.replaceSection(selectedRange.getStart(), selectedRange.getLength(), newInput);
 
         if (newText.isEmpty())
             return newText;

--- a/Source/cg_SectionGeneralSettings.cpp
+++ b/Source/cg_SectionGeneralSettings.cpp
@@ -119,8 +119,8 @@ SectionGeneralSettings::SectionGeneralSettings(GrisLookAndFeel & grisLookAndFeel
 
     mNumOfSourcesEditor.setExplicitFocusOrder(2);
     mNumOfSourcesEditor.setText("2");
-    mNumOfSourcesEditor.setInputFilter(new NumberRangeInputFilter(1, gris::MAX_NUMBER_OF_SOURCES), true);
-
+    auto const MAX_NUMBER_OF_SOURCES { juce::JUCEApplicationBase::isStandaloneApp() ? 128 : 8};
+    mNumOfSourcesEditor.setInputFilter(new NumberRangeInputFilter(1, MAX_NUMBER_OF_SOURCES), true);
     mNumOfSourcesEditor.onReturnKey = [this] { mOscFormatCombo.grabKeyboardFocus(); };
     mNumOfSourcesEditor.onFocusLost = [this] {
         if (!mNumOfSourcesEditor.isEmpty()) {

--- a/Source/cg_SectionGeneralSettings.cpp
+++ b/Source/cg_SectionGeneralSettings.cpp
@@ -41,26 +41,112 @@ public:
     juce::String filterNewText(juce::TextEditor & editor, const juce::String & newInput) override
     {
         auto const currentText{ editor.getText() };
-        auto newText{ currentText + newInput };
-
+        auto const isNewInputDigit { newInput.containsOnly("0123456789") };
+        auto const validNewInput {isNewInputDigit ? newInput : ""};
+        auto newText{ currentText + validNewInput };
         auto const selectedRange { editor.getHighlightedRegion() };
-        if (! selectedRange.isEmpty())
-            newText = currentText.replaceSection(selectedRange.getStart(), selectedRange.getLength(), newInput);
+
+        if (! selectedRange.isEmpty() && ! validNewInput.isEmpty())
+            newText = currentText.replaceSection(selectedRange.getStart(), selectedRange.getLength(), validNewInput);
 
         if (newText.isEmpty())
             return newText;
 
         const auto value{ newText.getIntValue() };
-        if (value >= minValue && value <= maxValue)
-            return newInput;
+        if (value >= minValue && value <= maxValue && isNewInputDigit)
+            return validNewInput;
 
-        return {};
+        if (selectedRange.isEmpty())
+            return {};
+        else
+            return currentText.substring(selectedRange.getStart(), selectedRange.getEnd());
     }
 
 private:
     int minValue;
     int maxValue;
 };
+
+// Unit test for NumberRangeInputFilter
+class NumberRangeInputFilterTest : public juce::UnitTest
+{
+public:
+    NumberRangeInputFilterTest() : juce::UnitTest("NumberRangeInputFilterTest") {}
+
+    void runTest() override
+    {
+        beginTest("NumberRangeInputFilter allows valid input");
+
+        {
+            juce::TextEditor editor;
+            editor.setInputFilter(new NumberRangeInputFilter(1, 128), true);
+
+            editor.insertTextAtCaret("12");
+            expectEquals(editor.getText().getIntValue(), 12);
+        }
+
+        beginTest("NumberRangeInputFilter disallows out-of-bound inputs");
+
+        {
+            juce::TextEditor editor;
+            editor.setInputFilter(new NumberRangeInputFilter(1, 8), true);
+
+            editor.insertTextAtCaret("-1");
+            expectEquals(editor.getText().getIntValue(), 0);
+
+            editor.insertTextAtCaret("9");
+            expectEquals(editor.getText().getIntValue(), 0);
+
+            editor.insertTextAtCaret("&");
+            expectEquals(editor.getText().getIntValue(), 0);
+
+            editor.insertTextAtCaret(juce::CharPointer_UTF8 ("é"));
+            expectEquals(editor.getText().getIntValue(), 0);
+        }
+
+        beginTest("NumberRangeInputFilter handles partial input");
+
+        {
+            juce::TextEditor editor;
+            editor.setInputFilter(new NumberRangeInputFilter(1, 128), true);
+
+            // append 3 to 12 --> should be 123
+            editor.insertTextAtCaret("12");
+            editor.insertTextAtCaret("3");
+            expectEquals(editor.getText().getIntValue(), 123);
+
+            //append 9 to 12 --> should stay at 12
+            editor.clear();
+            editor.insertTextAtCaret("12");
+            editor.insertTextAtCaret("9");
+            expectEquals(editor.getText().getIntValue(), 12);
+
+            // replace the middle 1 in 111 with 2 --> should be 121
+            editor.clear();
+            editor.insertTextAtCaret("111");
+            editor.setHighlightedRegion({1,2});
+            editor.insertTextAtCaret("2");
+            expectEquals(editor.getText().getIntValue(), 121);
+
+            // replace the middle 1 in 111 with 222 --> should stay 111
+            editor.clear();
+            editor.insertTextAtCaret("111");
+            editor.setHighlightedRegion({ 1, 2 });
+            editor.insertTextAtCaret("222");
+            expectEquals(editor.getText().getIntValue(), 111);
+
+            // replace the 23 in 123 with random garbage --> should stay 111
+            editor.clear();
+            editor.insertTextAtCaret("123");
+            editor.setHighlightedRegion({ 1, 3 });
+            editor.insertTextAtCaret(juce::CharPointer_UTF8("ééé123ööö"));
+            expectEquals(editor.getText().getIntValue(), 123);
+        }
+    }
+};
+
+// This will automatically create an instance of the test class and add it to the list of tests to be run.
+static NumberRangeInputFilterTest numberRangeInputFilterTest;
 
 //==============================================================================
 SectionGeneralSettings::SectionGeneralSettings(GrisLookAndFeel & grisLookAndFeel) : mGrisLookAndFeel(grisLookAndFeel)

--- a/Source/cg_Source.hpp
+++ b/Source/cg_Source.hpp
@@ -287,8 +287,9 @@ class Sources
     std::vector<Source> mSecondarySources{};
 
 public:
+    const int MAX_NUMBER_OF_SOURCES;
     //==============================================================================
-    Sources()
+    Sources() : MAX_NUMBER_OF_SOURCES(juce::JUCEApplicationBase::isStandaloneApp() ? 128 : 8)
     {
         mSecondarySources.resize(MAX_NUMBER_OF_SOURCES - 1);
     }

--- a/Source/cg_Source.hpp
+++ b/Source/cg_Source.hpp
@@ -59,17 +59,17 @@ public:
 
     // Move constructor
     Source(Source && other) noexcept
-        : mIndex(std::move(other.mIndex))
-        , mId(std::move(other.mId))
-        , mSpatMode(std::move(other.mSpatMode))
-        , mAzimuth(std::move(other.mAzimuth))
-        , mElevation(std::move(other.mElevation))
-        , mDistance(std::move(other.mDistance))
-        , mPosition(std::move(other.mPosition))
-        , mAzimuthSpan(std::move(other.mAzimuthSpan))
-        , mElevationSpan(std::move(other.mElevationSpan))
+        : mIndex(other.mIndex)
+        , mId(other.mId)
+        , mSpatMode(other.mSpatMode)
+        , mAzimuth(other.mAzimuth)
+        , mElevation(other.mElevation)
+        , mDistance(other.mDistance)
+        , mPosition(other.mPosition)
+        , mAzimuthSpan(other.mAzimuthSpan)
+        , mElevationSpan(other.mElevationSpan)
         , mColour(std::move(other.mColour))
-        , mProcessor(std::move(other.mProcessor))
+        , mProcessor(other.mProcessor)
     {
     }
 
@@ -289,7 +289,7 @@ class Sources
 public:
     const int MAX_NUMBER_OF_SOURCES;
     //==============================================================================
-    Sources() : MAX_NUMBER_OF_SOURCES(juce::JUCEApplicationBase::isStandaloneApp() ? 128 : 8)
+    Sources() : MAX_NUMBER_OF_SOURCES(juce::JUCEApplicationBase::isStandaloneApp() ? 256 : 8)
     {
         mSecondarySources.resize(MAX_NUMBER_OF_SOURCES - 1);
     }

--- a/Source/cg_Source.hpp
+++ b/Source/cg_Source.hpp
@@ -20,31 +20,109 @@
 
 #pragma once
 
-#include <array>
-
-#include <JuceHeader.h>
-
 #include "cg_StrongTypes.hpp"
 #include "cg_constants.hpp"
+#include <JuceHeader.h>
+#include <vector>
 
 namespace gris
 {
 //==============================================================================
+// Forward declaration
 class ControlGrisAudioProcessor;
 
 enum class SourceParameter { azimuth, elevation, distance, x, y, azimuthSpan, elevationSpan };
+
 //==============================================================================
+// Source class definition
 class Source
 {
 public:
+    // Default constructor
+    Source() = default;
+
+    // Copy constructor
+    Source(const Source & other)
+        : mIndex(other.mIndex)
+        , mId(other.mId)
+        , mSpatMode(other.mSpatMode)
+        , mAzimuth(other.mAzimuth)
+        , mElevation(other.mElevation)
+        , mDistance(other.mDistance)
+        , mPosition(other.mPosition)
+        , mAzimuthSpan(other.mAzimuthSpan)
+        , mElevationSpan(other.mElevationSpan)
+        , mColour(other.mColour)
+        , mProcessor(other.mProcessor)
+    {
+    }
+
+    // Move constructor
+    Source(Source && other) noexcept
+        : mIndex(std::move(other.mIndex))
+        , mId(std::move(other.mId))
+        , mSpatMode(std::move(other.mSpatMode))
+        , mAzimuth(std::move(other.mAzimuth))
+        , mElevation(std::move(other.mElevation))
+        , mDistance(std::move(other.mDistance))
+        , mPosition(std::move(other.mPosition))
+        , mAzimuthSpan(std::move(other.mAzimuthSpan))
+        , mElevationSpan(std::move(other.mElevationSpan))
+        , mColour(std::move(other.mColour))
+        , mProcessor(std::move(other.mProcessor))
+    {
+    }
+
+    // Copy assignment operator
+    Source & operator=(const Source & other)
+    {
+        if (this != &other) {
+            mIndex = other.mIndex;
+            mId = other.mId;
+            mSpatMode = other.mSpatMode;
+            mAzimuth = other.mAzimuth;
+            mElevation = other.mElevation;
+            mDistance = other.mDistance;
+            mPosition = other.mPosition;
+            mAzimuthSpan = other.mAzimuthSpan;
+            mElevationSpan = other.mElevationSpan;
+            mColour = other.mColour;
+            mProcessor = other.mProcessor;
+        }
+        return *this;
+    }
+
+    // Move assignment operator
+    Source & operator=(Source && other) noexcept
+    {
+        if (this != &other) {
+            mIndex = std::move(other.mIndex);
+            mId = std::move(other.mId);
+            mSpatMode = std::move(other.mSpatMode);
+            mAzimuth = std::move(other.mAzimuth);
+            mElevation = std::move(other.mElevation);
+            mDistance = std::move(other.mDistance);
+            mPosition = std::move(other.mPosition);
+            mAzimuthSpan = std::move(other.mAzimuthSpan);
+            mElevationSpan = std::move(other.mElevationSpan);
+            mColour = std::move(other.mColour);
+            mProcessor = std::move(other.mProcessor);
+        }
+        return *this;
+    }
+
     //==============================================================================
+
     enum class OriginOfChange { none, userMove, userAnchorMove, link, trajectory, automation, presetRecall, osc };
     enum class ChangeType { position, elevation };
+
     //==============================================================================
+
     class Listener : private juce::AsyncUpdater
     {
     public:
         //==============================================================================
+
         Listener() = default;
         virtual ~Listener() override = default;
 
@@ -53,20 +131,25 @@ public:
 
         Listener & operator=(Listener const &) = delete;
         Listener & operator=(Listener &&) = delete;
+
         //==============================================================================
+
         void update() { triggerAsyncUpdate(); }
 
     private:
         //==============================================================================
+
         void handleAsyncUpdate() override { sourceMovedCallback(); }
         virtual void sourceMovedCallback() = 0;
-        //==============================================================================
-        JUCE_LEAK_DETECTOR(Listener)
 
-    }; // class Source::Listener
+        //==============================================================================
+
+        JUCE_LEAK_DETECTOR(Listener)
+    };
 
 private:
     //==============================================================================
+
     juce::ListenerList<Listener> mGuiListeners;
 
     SourceIndex mIndex{};
@@ -87,6 +170,7 @@ private:
 
 public:
     //==============================================================================
+
     void setIndex(SourceIndex const index) { mIndex = index; }
     [[nodiscard]] SourceIndex getIndex() const { return mIndex; }
 
@@ -145,23 +229,30 @@ public:
 
 private:
     //==============================================================================
+
     bool shouldForceNotifications(OriginOfChange origin) const;
     void notify(ChangeType changeType, OriginOfChange origin);
     void notifyGuiListeners();
     static Radians clipElevation(Radians elevation);
     static float clipCoordinate(float coord);
+
     //==============================================================================
+
     JUCE_LEAK_DETECTOR(Source)
 };
 
 //==============================================================================
+// Sources class definition
 class Sources
 {
     //==============================================================================
+
     struct Iterator {
         Sources * sources;
         int index;
+
         //==============================================================================
+
         bool operator!=(Iterator const & other) const { return index != other.index; }
         Iterator & operator++()
         {
@@ -171,11 +262,15 @@ class Sources
         Source & operator*() { return sources->get(index); }
         Source const & operator*() const { return sources->get(index); }
     };
+
     //==============================================================================
+
     struct ConstIterator {
         Sources const * sources;
         int index;
+
         //==============================================================================
+
         bool operator!=(ConstIterator const & other) const { return index != other.index; }
         ConstIterator & operator++()
         {
@@ -184,13 +279,16 @@ class Sources
         }
         Source const & operator*() const { return sources->get(index); }
     };
+
     //==============================================================================
+
     int mSize{ 2 };
     Source mPrimarySource;
-    std::array<Source, MAX_NUMBER_OF_SOURCES - 1> mSecondarySources{};
+    std::vector<Source> mSecondarySources{};
 
 public:
     //==============================================================================
+
     [[nodiscard]] int size() const { return mSize; }
     void setSize(int size);
 
@@ -236,6 +334,7 @@ public:
         SourceIndex currentIndex{};
         mPrimarySource.setIndex(currentIndex++);
         mPrimarySource.setProcessor(processor);
+        mSecondarySources.resize(MAX_NUMBER_OF_SOURCES - 1);
         for (auto & secondarySource : mSecondarySources) {
             secondarySource.setIndex(currentIndex++);
             secondarySource.setProcessor(processor);
@@ -254,6 +353,7 @@ public:
 
 private:
     //==============================================================================
+
     JUCE_LEAK_DETECTOR(Sources)
 };
 

--- a/Source/cg_Source.hpp
+++ b/Source/cg_Source.hpp
@@ -288,6 +288,10 @@ class Sources
 
 public:
     //==============================================================================
+    Sources()
+    {
+        mSecondarySources.resize(MAX_NUMBER_OF_SOURCES - 1);
+    }
 
     [[nodiscard]] int size() const { return mSize; }
     void setSize(int size);

--- a/Source/cg_SourceLinkEnforcer.cpp
+++ b/Source/cg_SourceLinkEnforcer.cpp
@@ -160,7 +160,7 @@ void SourceLinkEnforcer::secondarySourceMoved(SourceIndex const sourceIndex)
         SourceSnapshot const secondaryEnd{ mSources[sourceIndex] };
 
         // take a snapshot of sources length ratios if mLinkStrategy is circularFixedAngle
-        std::vector<float> tmpFixedAngleSecSourcesLengthRatio;
+        auto tmpFixedAngleSecSourcesLengthRatio = std::vector<float>(mSources.MAX_NUMBER_OF_SOURCES);
         if (mLinkStrategy.get()->isInitialized()) {
             if (mPositionSourceLink == PositionSourceLink::circularFixedAngle) {
                 source_link_strategies::CircularFixedAngle * circularFixedLinkStrategy
@@ -170,7 +170,7 @@ void SourceLinkEnforcer::secondarySourceMoved(SourceIndex const sourceIndex)
         }
 
         // take a snapshot of source ordering if mLinkStrategy is circularFullyFixed
-        std::vector<int> tmpCircularFullyFixedOrdering;
+        auto tmpCircularFullyFixedOrdering = std::vector<int>(mSources.MAX_NUMBER_OF_SOURCES);
         if (mLinkStrategy.get()->isInitialized()) {
             if (mPositionSourceLink == PositionSourceLink::circularFullyFixed) {
                 source_link_strategies::CircularFullyFixed * circularFullyFixedLinkStrategy

--- a/Source/cg_SourceLinkEnforcer.cpp
+++ b/Source/cg_SourceLinkEnforcer.cpp
@@ -160,7 +160,7 @@ void SourceLinkEnforcer::secondarySourceMoved(SourceIndex const sourceIndex)
         SourceSnapshot const secondaryEnd{ mSources[sourceIndex] };
 
         // take a snapshot of sources length ratios if mLinkStrategy is circularFixedAngle
-        std::array<float, MAX_NUMBER_OF_SOURCES> tmpFixedAngleSecSourcesLengthRatio;
+        std::vector<float> tmpFixedAngleSecSourcesLengthRatio;
         if (mLinkStrategy.get()->isInitialized()) {
             if (mPositionSourceLink == PositionSourceLink::circularFixedAngle) {
                 source_link_strategies::CircularFixedAngle * circularFixedLinkStrategy
@@ -170,7 +170,7 @@ void SourceLinkEnforcer::secondarySourceMoved(SourceIndex const sourceIndex)
         }
 
         // take a snapshot of source ordering if mLinkStrategy is circularFullyFixed
-        std::array<int, MAX_NUMBER_OF_SOURCES> tmpCircularFullyFixedOrdering;
+        std::vector<int> tmpCircularFullyFixedOrdering;
         if (mLinkStrategy.get()->isInitialized()) {
             if (mPositionSourceLink == PositionSourceLink::circularFullyFixed) {
                 source_link_strategies::CircularFullyFixed * circularFullyFixedLinkStrategy

--- a/Source/cg_SourceLinkEnforcer.cpp
+++ b/Source/cg_SourceLinkEnforcer.cpp
@@ -126,7 +126,7 @@ void SourceLinkEnforcer::primarySourceMoved()
 //==============================================================================
 void SourceLinkEnforcer::secondarySourceMoved(SourceIndex const sourceIndex)
 {
-    jassert(sourceIndex.get() > 0 && sourceIndex.get() < MAX_NUMBER_OF_SOURCES);
+    jassert(sourceIndex.get() > 0 && sourceIndex.get() < mSources.MAX_NUMBER_OF_SOURCES);
 
     auto const spatMode{ mSources.getPrimarySource().getSpatMode() };
     auto const isElevationSourceLink{ mElevationSourceLink != ElevationSourceLink::undefined };
@@ -243,7 +243,7 @@ void SourceLinkEnforcer::primaryAnchorMoved()
 //==============================================================================
 void SourceLinkEnforcer::secondaryAnchorMoved(SourceIndex const sourceIndex)
 {
-    jassert(sourceIndex.get() > 0 && sourceIndex.get() < MAX_NUMBER_OF_SOURCES);
+    jassert(sourceIndex.get() > 0 && sourceIndex.get() < mSources.MAX_NUMBER_OF_SOURCES);
 
     auto const secondaryIndex{ sourceIndex.get() - 1 };
     auto & snapshot{ mSnapshots.secondaries.getReference(secondaryIndex) };

--- a/Source/cg_constants.hpp
+++ b/Source/cg_constants.hpp
@@ -27,12 +27,6 @@ namespace gris
 // Global variables.
 constexpr int MIN_FIELD_WIDTH = 300;
 
-//static int initMaxNumberOfSources()
-//{
-//    return juce::JUCEApplication::getInstance()->isStandaloneApp() ? 8 : 128;
-//}
-//const int MAX_NUMBER_OF_SOURCES{ initMaxNumberOfSources() };
-
 constexpr int NUMBER_OF_POSITION_PRESETS = 50;
 constexpr float SOURCE_FIELD_COMPONENT_RADIUS = 12.0f;
 constexpr float SOURCE_FIELD_COMPONENT_DIAMETER = SOURCE_FIELD_COMPONENT_RADIUS * 2.0f;

--- a/Source/cg_constants.hpp
+++ b/Source/cg_constants.hpp
@@ -27,7 +27,11 @@ namespace gris
 // Global variables.
 constexpr int MIN_FIELD_WIDTH = 300;
 
-const int MAX_NUMBER_OF_SOURCES { juce::JUCEApplication::getInstance()->isStandaloneApp() ? 128 : 9 };
+static int initMaxNumberOfSources()
+{
+    return juce::JUCEApplication::getInstance()->isStandaloneApp() ? 8 : 128;
+}
+const int MAX_NUMBER_OF_SOURCES{ initMaxNumberOfSources() };
 
 constexpr int NUMBER_OF_POSITION_PRESETS = 50;
 constexpr float SOURCE_FIELD_COMPONENT_RADIUS = 12.0f;

--- a/Source/cg_constants.hpp
+++ b/Source/cg_constants.hpp
@@ -26,7 +26,19 @@ namespace gris
 //==============================================================================
 // Global variables.
 constexpr int MIN_FIELD_WIDTH = 300;
-constexpr int MAX_NUMBER_OF_SOURCES = 800;
+
+static int initializeMaxNumberOfSources()
+{
+    if (!juce::JUCEApplication::getInstance()->isStandaloneApp()) {
+        return 128; // or any other value you want to set
+    } else {
+        return 8; // or any other value you want to set for standalone app
+    }
+}
+
+const int MAX_NUMBER_OF_SOURCES = initializeMaxNumberOfSources();
+
+
 constexpr int NUMBER_OF_POSITION_PRESETS = 50;
 constexpr float SOURCE_FIELD_COMPONENT_RADIUS = 12.0f;
 constexpr float SOURCE_FIELD_COMPONENT_DIAMETER = SOURCE_FIELD_COMPONENT_RADIUS * 2.0f;

--- a/Source/cg_constants.hpp
+++ b/Source/cg_constants.hpp
@@ -27,17 +27,7 @@ namespace gris
 // Global variables.
 constexpr int MIN_FIELD_WIDTH = 300;
 
-static int initializeMaxNumberOfSources()
-{
-    if (!juce::JUCEApplication::getInstance()->isStandaloneApp()) {
-        return 128; // or any other value you want to set
-    } else {
-        return 8; // or any other value you want to set for standalone app
-    }
-}
-
-const int MAX_NUMBER_OF_SOURCES = initializeMaxNumberOfSources();
-
+const int MAX_NUMBER_OF_SOURCES { juce::JUCEApplication::getInstance()->isStandaloneApp() ? 128 : 9 };
 
 constexpr int NUMBER_OF_POSITION_PRESETS = 50;
 constexpr float SOURCE_FIELD_COMPONENT_RADIUS = 12.0f;

--- a/Source/cg_constants.hpp
+++ b/Source/cg_constants.hpp
@@ -26,7 +26,7 @@ namespace gris
 //==============================================================================
 // Global variables.
 constexpr int MIN_FIELD_WIDTH = 300;
-constexpr int MAX_NUMBER_OF_SOURCES = 8;
+constexpr int MAX_NUMBER_OF_SOURCES = 800;
 constexpr int NUMBER_OF_POSITION_PRESETS = 50;
 constexpr float SOURCE_FIELD_COMPONENT_RADIUS = 12.0f;
 constexpr float SOURCE_FIELD_COMPONENT_DIAMETER = SOURCE_FIELD_COMPONENT_RADIUS * 2.0f;

--- a/Source/cg_constants.hpp
+++ b/Source/cg_constants.hpp
@@ -27,11 +27,11 @@ namespace gris
 // Global variables.
 constexpr int MIN_FIELD_WIDTH = 300;
 
-static int initMaxNumberOfSources()
-{
-    return juce::JUCEApplication::getInstance()->isStandaloneApp() ? 8 : 128;
-}
-const int MAX_NUMBER_OF_SOURCES{ initMaxNumberOfSources() };
+//static int initMaxNumberOfSources()
+//{
+//    return juce::JUCEApplication::getInstance()->isStandaloneApp() ? 8 : 128;
+//}
+//const int MAX_NUMBER_OF_SOURCES{ initMaxNumberOfSources() };
 
 constexpr int NUMBER_OF_POSITION_PRESETS = 50;
 constexpr float SOURCE_FIELD_COMPONENT_RADIUS = 12.0f;


### PR DESCRIPTION
Fixes #202 :
- Add linux build github action pipeline
- add Standalone option in Projucer -- had to take out AAX and VST to get the pipeline to work. Neither of these should be required at this point?
- make the max number of source 128 when running in standalone, while keeping 8 for plugin-mode
- enable juce unit tests (for now) and add a unit test for the number of sources editor
- enable plugin copy step post build
