### PR TITLE
227: Save (and restore) number of sources and first source ID in presets

### DIFF
--- a/Source/cg_ControlGrisAudioProcessor.cpp
+++ b/Source/cg_ControlGrisAudioProcessor.cpp
@@ -359,8 +359,6 @@ void ControlGrisAudioProcessor::setNumberOfSources(int const numOfSources, bool 
     mPositionSourceLinkEnforcer.numberOfSourcesChanged();
     mElevationSourceLinkEnforcer.numberOfSourcesChanged();
 
-    mPresetManager.numberOfSourcesChanged();
-
     auto const positionSourceLink{ mPositionTrajectoryManager.getSourceLink() };
     auto const isSymmetricLink{ positionSourceLink == PositionSourceLink::symmetricX
                                 || positionSourceLink == PositionSourceLink::symmetricY };

--- a/Source/cg_ControlGrisAudioProcessor.hpp
+++ b/Source/cg_ControlGrisAudioProcessor.hpp
@@ -96,7 +96,8 @@ class ControlGrisAudioProcessor final
     PresetsManager mPresetManager{ mFixPositionData,
                                    mSources,
                                    mPositionSourceLinkEnforcer,
-                                   mElevationSourceLinkEnforcer };
+                                   mElevationSourceLinkEnforcer,
+                                   mFirstSourceId };
 
     PositionTrajectoryManager mPositionTrajectoryManager{ *this, mSources.getPrimarySource() };
     ElevationTrajectoryManager mElevationTrajectoryManager{ *this, mSources.getPrimarySource() };

--- a/Source/cg_ControlGrisAudioProcessorEditor.cpp
+++ b/Source/cg_ControlGrisAudioProcessorEditor.cpp
@@ -712,6 +712,9 @@ void ControlGrisAudioProcessorEditor::positionPresetChangedCallback(int const pr
     mProcessor.getPresetsManager().forceLoad(presetNumber);
     numberOfSourcesChangedCallback(mProcessor.getSources().size());
 
+    if (auto const presetSourceId {mProcessor.getPresetsManager().getPresetSourceId(presetNumber)})
+        firstSourceIdChangedCallback(SourceId{*presetSourceId});
+
     auto * parameter{ mAudioProcessorValueTreeState.getParameter(Automation::Ids::POSITION_PRESET) };
     auto const newValue{ static_cast<float>(presetNumber) / static_cast<float>(NUMBER_OF_POSITION_PRESETS) };
 
@@ -719,9 +722,8 @@ void ControlGrisAudioProcessorEditor::positionPresetChangedCallback(int const pr
     parameter->setValueNotifyingHost(newValue);
 
     mProcessor.updatePrimarySourceParameters(Source::ChangeType::position);
-    if (mProcessor.getSpatMode() == SpatMode::cube) {
+    if (mProcessor.getSpatMode() == SpatMode::cube)
         mProcessor.updatePrimarySourceParameters(Source::ChangeType::elevation);
-    }
 }
 
 //==============================================================================

--- a/Source/cg_ControlGrisAudioProcessorEditor.cpp
+++ b/Source/cg_ControlGrisAudioProcessorEditor.cpp
@@ -364,16 +364,18 @@ void ControlGrisAudioProcessorEditor::oscStateChangedCallback(bool const state)
 //==============================================================================
 void ControlGrisAudioProcessorEditor::numberOfSourcesChangedCallback(int const numOfSources)
 {
+    auto const initSourcePlacement{ mProcessor.getSources().size() != numOfSources };
     auto const currentPositionSourceLink{ mPositionTrajectoryManager.getSourceLink() };
     auto const symmetricLinkAllowed{ numOfSources == 2 };
     mSectionTrajectory.setSymmetricLinkComboState(symmetricLinkAllowed);
     if (!symmetricLinkAllowed) {
         auto const isCurrentPositionSourceLinkSymmetric{ currentPositionSourceLink == PositionSourceLink::symmetricX
-                                                         || currentPositionSourceLink == PositionSourceLink::symmetricY };
-        if (isCurrentPositionSourceLinkSymmetric)
+                                                         || currentPositionSourceLink
+                                                                == PositionSourceLink::symmetricY };
+        if (isCurrentPositionSourceLinkSymmetric) {
             mProcessor.setPositionSourceLink(PositionSourceLink::independent, SourceLinkEnforcer::OriginOfChange::user);
+        }
     }
-
     mSelectedSource = {};
     mProcessor.setNumberOfSources(numOfSources);
     mSectionGeneralSettings.setNumberOfSources(numOfSources);
@@ -382,6 +384,9 @@ void ControlGrisAudioProcessorEditor::numberOfSourcesChangedCallback(int const n
     mPositionField.refreshSources();
     mElevationField.refreshSources();
     mSectionSourcePosition.setNumberOfSources(numOfSources, mProcessor.getFirstSourceId());
+    if (initSourcePlacement) {
+        sourcesPlacementChangedCallback(SourcePlacement::leftAlternate);
+    }
 }
 
 //==============================================================================

--- a/Source/cg_ControlGrisAudioProcessorEditor.cpp
+++ b/Source/cg_ControlGrisAudioProcessorEditor.cpp
@@ -364,7 +364,8 @@ void ControlGrisAudioProcessorEditor::oscStateChangedCallback(bool const state)
 //==============================================================================
 void ControlGrisAudioProcessorEditor::numberOfSourcesChangedCallback(int const numOfSources)
 {
-    if (mProcessor.getSources().size() != numOfSources || mIsInsideSetPluginState) {
+    // NOW HERE: had to bypass this logic, how bad is it? Also first time round it looks like the position is reset
+    if (true || mProcessor.getSources().size() != numOfSources || mIsInsideSetPluginState) {
         auto const initSourcePlacement{ mProcessor.getSources().size() != numOfSources };
         auto const currentPositionSourceLink{ mPositionTrajectoryManager.getSourceLink() };
         auto const symmetricLinkAllowed{ numOfSources == 2 };
@@ -719,6 +720,7 @@ void ControlGrisAudioProcessorEditor::fieldSourcePositionChangedCallback(SourceI
 void ControlGrisAudioProcessorEditor::positionPresetChangedCallback(int const presetNumber)
 {
     mProcessor.getPresetsManager().forceLoad(presetNumber);
+    numberOfSourcesChangedCallback(mProcessor.getSources().size());
 
     auto * parameter{ mAudioProcessorValueTreeState.getParameter(Automation::Ids::POSITION_PRESET) };
     auto const newValue{ static_cast<float>(presetNumber) / static_cast<float>(NUMBER_OF_POSITION_PRESETS) };

--- a/Source/cg_ControlGrisAudioProcessorEditor.cpp
+++ b/Source/cg_ControlGrisAudioProcessorEditor.cpp
@@ -364,34 +364,24 @@ void ControlGrisAudioProcessorEditor::oscStateChangedCallback(bool const state)
 //==============================================================================
 void ControlGrisAudioProcessorEditor::numberOfSourcesChangedCallback(int const numOfSources)
 {
-    // NOW HERE: had to bypass this logic, how bad is it? Also first time round it looks like the position is reset
-    if (true || mProcessor.getSources().size() != numOfSources || mIsInsideSetPluginState) {
-        auto const initSourcePlacement{ mProcessor.getSources().size() != numOfSources };
-        auto const currentPositionSourceLink{ mPositionTrajectoryManager.getSourceLink() };
-        auto const symmetricLinkAllowed{ numOfSources == 2 };
-        mSectionTrajectory.setSymmetricLinkComboState(symmetricLinkAllowed);
-        if (!symmetricLinkAllowed) {
-            auto const isCurrentPositionSourceLinkSymmetric{ currentPositionSourceLink == PositionSourceLink::symmetricX
-                                                             || currentPositionSourceLink
-                                                                    == PositionSourceLink::symmetricY };
-            if (isCurrentPositionSourceLinkSymmetric) {
-                mProcessor.setPositionSourceLink(PositionSourceLink::independent,
-                                                 SourceLinkEnforcer::OriginOfChange::user);
-            }
-        }
-
-        mSelectedSource = {};
-        mProcessor.setNumberOfSources(numOfSources);
-        mSectionGeneralSettings.setNumberOfSources(numOfSources);
-        mSectionTrajectory.setNumberOfSources(numOfSources);
-        mSectionSourceSpan.setSelectedSource(&mProcessor.getSources()[mSelectedSource]);
-        mPositionField.refreshSources();
-        mElevationField.refreshSources();
-        mSectionSourcePosition.setNumberOfSources(numOfSources, mProcessor.getFirstSourceId());
-        if (initSourcePlacement) {
-            sourcesPlacementChangedCallback(SourcePlacement::leftAlternate);
-        }
+    auto const currentPositionSourceLink{ mPositionTrajectoryManager.getSourceLink() };
+    auto const symmetricLinkAllowed{ numOfSources == 2 };
+    mSectionTrajectory.setSymmetricLinkComboState(symmetricLinkAllowed);
+    if (!symmetricLinkAllowed) {
+        auto const isCurrentPositionSourceLinkSymmetric{ currentPositionSourceLink == PositionSourceLink::symmetricX
+                                                         || currentPositionSourceLink == PositionSourceLink::symmetricY };
+        if (isCurrentPositionSourceLinkSymmetric)
+            mProcessor.setPositionSourceLink(PositionSourceLink::independent, SourceLinkEnforcer::OriginOfChange::user);
     }
+
+    mSelectedSource = {};
+    mProcessor.setNumberOfSources(numOfSources);
+    mSectionGeneralSettings.setNumberOfSources(numOfSources);
+    mSectionTrajectory.setNumberOfSources(numOfSources);
+    mSectionSourceSpan.setSelectedSource(&mProcessor.getSources()[mSelectedSource]);
+    mPositionField.refreshSources();
+    mElevationField.refreshSources();
+    mSectionSourcePosition.setNumberOfSources(numOfSources, mProcessor.getFirstSourceId());
 }
 
 //==============================================================================

--- a/Source/cg_ControlGrisAudioProcessorEditor.cpp
+++ b/Source/cg_ControlGrisAudioProcessorEditor.cpp
@@ -722,8 +722,9 @@ void ControlGrisAudioProcessorEditor::positionPresetChangedCallback(int const pr
     parameter->setValueNotifyingHost(newValue);
 
     mProcessor.updatePrimarySourceParameters(Source::ChangeType::position);
-    if (mProcessor.getSpatMode() == SpatMode::cube)
+    if (mProcessor.getSpatMode() == SpatMode::cube) {
         mProcessor.updatePrimarySourceParameters(Source::ChangeType::elevation);
+    }
 }
 
 //==============================================================================

--- a/Source/cg_LinkStrategies.hpp
+++ b/Source/cg_LinkStrategies.hpp
@@ -82,7 +82,7 @@ private:
 }; // class Base
 
 //==============================================================================
-// only use full to recall saved positions
+// only useful to recall saved positions
 class PositionIndependent final : public Base
 {
     void computeParameters_implementation(Sources const &, SourcesSnapshots const &) override {}
@@ -240,7 +240,7 @@ class PositionDeltaLock final : public Base
 };
 
 //==============================================================================
-// only usefuLl to recall saved positions
+// only useful to recall saved positions
 class ElevationIndependent final : public Base
 {
     void computeParameters_implementation(Sources const &, SourcesSnapshots const &) override {}

--- a/Source/cg_PresetsManager.cpp
+++ b/Source/cg_PresetsManager.cpp
@@ -139,8 +139,9 @@ bool PresetsManager::load(int const presetNumber)
 
         //load the snapshots into the enforcers, which are references to the ControlGrisAudioProcessor members
         mPositionLinkEnforcer.loadSnapshots(snapshots);
-        if (mSources.getPrimarySource().getSpatMode() == SpatMode::cube)
+        if (mSources.getPrimarySource().getSpatMode() == SpatMode::cube) {
             mElevationLinkEnforcer.loadSnapshots(snapshots);
+        }
 
         auto const xTerminalPositionId{ getFixedPosSourceName(FixedPositionType::terminal, SourceIndex{ 0 }, 0) };
         auto const yTerminalPositionId{ getFixedPosSourceName(FixedPositionType::terminal, SourceIndex{ 0 }, 1) };
@@ -153,8 +154,10 @@ bool PresetsManager::load(int const presetNumber)
                 static_cast<float>(presetData->getDoubleAttribute(xTerminalPositionId)),
                 static_cast<float>(presetData->getDoubleAttribute(yTerminalPositionId))
             };
-            auto const inversedTerminalPosition{ inversedNormalizedTerminalPosition * 2.0f - juce::Point<float>{ 1.0f, 1.0f } };
-            terminalPosition = juce::Point<float>{ inversedTerminalPosition.getX(), inversedTerminalPosition.getY() * -1.0f };
+            auto const inversedTerminalPosition{ inversedNormalizedTerminalPosition * 2.0f
+                                                 - juce::Point<float>{ 1.0f, 1.0f } };
+            terminalPosition
+                = juce::Point<float>{ inversedTerminalPosition.getX(), inversedTerminalPosition.getY() * -1.0f };
         } else {
             terminalPosition = snapshots.primary.position;
         }
@@ -163,7 +166,8 @@ bool PresetsManager::load(int const presetNumber)
         if (mSources.getPrimarySource().getSpatMode() == SpatMode::cube) {
             Radians elevation;
             if (presetData->hasAttribute(zTerminalPositionId)) {
-                auto const inversedNormalizedTerminalElevation{ static_cast<float>(presetData->getDoubleAttribute(zTerminalPositionId)) };
+                auto const inversedNormalizedTerminalElevation{ static_cast<float>(
+                    presetData->getDoubleAttribute(zTerminalPositionId)) };
                 elevation = MAX_ELEVATION * (1.0f - inversedNormalizedTerminalElevation);
             } else {
                 elevation = snapshots.primary.z;

--- a/Source/cg_PresetsManager.cpp
+++ b/Source/cg_PresetsManager.cpp
@@ -56,6 +56,7 @@ PresetsManager::PresetsManager(juce::XmlElement & data,
     , mPositionLinkEnforcer(positionLinkEnforcer)
     , mElevationLinkEnforcer(elevationLinkEnforcer)
 {
+    DBG("adf");
 }
 
 //==============================================================================
@@ -91,9 +92,14 @@ bool PresetsManager::load(int const presetNumber)
 
         auto const * presetData{ *maybe_presetData };
 
-        SourcesSnapshots snapshots{};
+//        if (presetData->hasAttribute("numSources"))
+//            mSources.setSize(<#int size#>)
+//            setNumberOfSources();
+    //        mAudioProcessorValueTreeState.state.setProperty("numberOfSources", 2, nullptr);
+
+        SourcesSnapshots snapshots;
         for (auto & source : mSources) {
-            SourceSnapshot snapshot{};
+            SourceSnapshot snapshot;
             auto const index{ source.getIndex() };
             auto const xPosId{ getFixedPosSourceName(FixedPositionType::initial, index, 0) };
             auto const yPosId{ getFixedPosSourceName(FixedPositionType::initial, index, 1) };
@@ -134,10 +140,8 @@ bool PresetsManager::load(int const presetNumber)
                 static_cast<float>(presetData->getDoubleAttribute(xTerminalPositionId)),
                 static_cast<float>(presetData->getDoubleAttribute(yTerminalPositionId))
             };
-            auto const inversedTerminalPosition{ inversedNormalizedTerminalPosition * 2.0f
-                                                 - juce::Point<float>{ 1.0f, 1.0f } };
-            terminalPosition
-                = juce::Point<float>{ inversedTerminalPosition.getX(), inversedTerminalPosition.getY() * -1.0f };
+            auto const inversedTerminalPosition{ inversedNormalizedTerminalPosition * 2.0f - juce::Point<float>{ 1.0f, 1.0f } };
+            terminalPosition = juce::Point<float>{ inversedTerminalPosition.getX(), inversedTerminalPosition.getY() * -1.0f };
         } else {
             terminalPosition = snapshots.primary.position;
         }
@@ -146,8 +150,7 @@ bool PresetsManager::load(int const presetNumber)
         if (mSources.getPrimarySource().getSpatMode() == SpatMode::cube) {
             Radians elevation;
             if (presetData->hasAttribute(zTerminalPositionId)) {
-                auto const inversedNormalizedTerminalElevation{ static_cast<float>(
-                    presetData->getDoubleAttribute(zTerminalPositionId)) };
+                auto const inversedNormalizedTerminalElevation{ static_cast<float>(presetData->getDoubleAttribute(zTerminalPositionId)) };
                 elevation = MAX_ELEVATION * (1.0f - inversedNormalizedTerminalElevation);
             } else {
                 elevation = snapshots.primary.z;
@@ -157,7 +160,7 @@ bool PresetsManager::load(int const presetNumber)
         }
     }
     mLastLoadedPreset = presetNumber;
-    sendChangeMessage();
+//    sendChangeMessage();
 
     return true;
 }
@@ -185,17 +188,20 @@ std::optional<juce::XmlElement *> PresetsManager::getPresetData(int const preset
 std::unique_ptr<juce::XmlElement> PresetsManager::createPresetData(int const presetNumber) const
 {
     // Build a new fixed position element.
-    auto result{ std::make_unique<juce::XmlElement>("ITEM") };
-    result->setAttribute("ID", presetNumber);
+    auto preset{ std::make_unique<juce::XmlElement>("ITEM") };
+    preset->setAttribute("ID", presetNumber);
 
     auto const & positionSnapshots{ mPositionLinkEnforcer.getSnapshots() };
     auto const & elevationsSnapshots{ mElevationLinkEnforcer.getSnapshots() };
 
+    //save the number and initial position of all sources
     SourceIndex const numberOfSources{ mSources.size() };
+    preset->setAttribute("numSources", numberOfSources.get());
+
     for (SourceIndex sourceIndex{}; sourceIndex < numberOfSources; ++sourceIndex) {
-        auto const xName{ getFixedPosSourceName(FixedPositionType::initial, sourceIndex, 0) };
-        auto const yName{ getFixedPosSourceName(FixedPositionType::initial, sourceIndex, 1) };
-        auto const zName{ getFixedPosSourceName(FixedPositionType::initial, sourceIndex, 2) };
+        auto const curSourceX{ getFixedPosSourceName(FixedPositionType::initial, sourceIndex, 0) };
+        auto const curSourceY{ getFixedPosSourceName(FixedPositionType::initial, sourceIndex, 1) };
+        auto const curSourceZ{ getFixedPosSourceName(FixedPositionType::initial, sourceIndex, 2) };
 
         auto const position{ positionSnapshots[sourceIndex].position };
         auto const elevation{ elevationsSnapshots[sourceIndex].z };
@@ -206,30 +212,28 @@ std::unique_ptr<juce::XmlElement> PresetsManager::createPresetData(int const pre
         auto const mirroredNormalizedPosition{ (mirroredPosition + juce::Point<float>{ 1.0f, 1.0f }) / 2.0f };
         auto const inversedNormalizedElevation{ 1.0f - normalizedElevation };
 
-        result->setAttribute(xName, mirroredNormalizedPosition.getX());
-        result->setAttribute(yName, mirroredNormalizedPosition.getY());
-        result->setAttribute(zName, inversedNormalizedElevation);
+        preset->setAttribute(curSourceX, mirroredNormalizedPosition.getX());
+        preset->setAttribute(curSourceY, mirroredNormalizedPosition.getY());
+        preset->setAttribute(curSourceZ, inversedNormalizedElevation);
     }
 
-    auto const xName{ getFixedPosSourceName(FixedPositionType::terminal, SourceIndex{ 0 }, 0) };
-    auto const yName{ getFixedPosSourceName(FixedPositionType::terminal, SourceIndex{ 0 }, 1) };
-    auto const zName{ getFixedPosSourceName(FixedPositionType::terminal, SourceIndex{ 0 }, 2) };
+    //TODO VB: is terminal the same as final?
+    //save the terminal position of only the first source
+    auto const firstSourceX{ getFixedPosSourceName(FixedPositionType::terminal, SourceIndex{ 0 }, 0) };
+    auto const firstSourceY{ getFixedPosSourceName(FixedPositionType::terminal, SourceIndex{ 0 }, 1) };
+    auto const firstSourceZ{ getFixedPosSourceName(FixedPositionType::terminal, SourceIndex{ 0 }, 2) };
 
+    // For some legacy reason, we store a normalized value with inversed Y and elevation
     auto const position{ mSources.getPrimarySource().getPos() };
-    juce::Point<float> const mirroredPosition{
-        position.getX(),
-        position.getY() * -1.0f
-    }; // For some legacy reason, we store a normalized value with inversed Y.
+    juce::Point<float> const mirroredPosition{ position.getX(), position.getY() * -1.0f };
     auto const inversedNormalizedPosition{ (mirroredPosition + juce::Point<float>{ 1.0f, 1.0f }) / 2.0f };
-    auto const inversedNormalizedElevation{
-        1.0f - mSources.getPrimarySource().getNormalizedElevation().get()
-    }; // Same this happens with elevation.
+    auto const inversedNormalizedElevation{ 1.0f - mSources.getPrimarySource().getNormalizedElevation().get() };
 
-    result->setAttribute(xName, inversedNormalizedPosition.getX());
-    result->setAttribute(yName, inversedNormalizedPosition.getY());
-    result->setAttribute(zName, inversedNormalizedElevation);
+    preset->setAttribute(firstSourceX, inversedNormalizedPosition.getX());
+    preset->setAttribute(firstSourceY, inversedNormalizedPosition.getY());
+    preset->setAttribute(firstSourceZ, inversedNormalizedElevation);
 
-    return result;
+    return preset;
 }
 
 //==============================================================================

--- a/Source/cg_PresetsManager.cpp
+++ b/Source/cg_PresetsManager.cpp
@@ -109,9 +109,9 @@ bool PresetsManager::load(int const presetNumber)
             mFirstSourceId = SourceId{ presetData->getIntAttribute("firstSourceId") };
 
         // Store the preset's source positions in a new SourcesSnapshots
-        SourcesSnapshots snapshots;
+        SourcesSnapshots snapshots{};
         for (auto & source : mSources) {
-            SourceSnapshot snapshot;
+            SourceSnapshot snapshot{};
             auto const index{ source.getIndex() };
             auto const xPosId{ getFixedPosSourceName(FixedPositionType::initial, index, 0) };
             auto const yPosId{ getFixedPosSourceName(FixedPositionType::initial, index, 1) };
@@ -234,13 +234,12 @@ std::unique_ptr<juce::XmlElement> PresetsManager::createPresetData(int const pre
         preset->setAttribute(curSourceZ, inversedNormalizedElevation);
     }
 
-    //TODO VB: is terminal the same as final?
     //save the terminal position of only the first source
     auto const firstSourceX{ getFixedPosSourceName(FixedPositionType::terminal, SourceIndex{ 0 }, 0) };
     auto const firstSourceY{ getFixedPosSourceName(FixedPositionType::terminal, SourceIndex{ 0 }, 1) };
     auto const firstSourceZ{ getFixedPosSourceName(FixedPositionType::terminal, SourceIndex{ 0 }, 2) };
 
-    // For some legacy reason, we store a normalized value with inversed Y and elevation
+    //The position is stored normalized with inversed Y and elevation
     auto const position{ mSources.getPrimarySource().getPos() };
     juce::Point<float> const mirroredPosition{ position.getX(), position.getY() * -1.0f };
     auto const inversedNormalizedPosition{ (mirroredPosition + juce::Point<float>{ 1.0f, 1.0f }) / 2.0f };

--- a/Source/cg_PresetsManager.cpp
+++ b/Source/cg_PresetsManager.cpp
@@ -108,7 +108,7 @@ bool PresetsManager::load(int const presetNumber)
         if (presetData->hasAttribute("firstSourceId"))
             mFirstSourceId = SourceId{ presetData->getIntAttribute("firstSourceId") };
 
-        //create a SourcesSnapshots and store in it the source positions from the preset
+        // Store the preset's source positions in a new SourcesSnapshots
         SourcesSnapshots snapshots;
         for (auto & source : mSources) {
             SourceSnapshot snapshot;
@@ -146,6 +146,7 @@ bool PresetsManager::load(int const presetNumber)
         auto const yTerminalPositionId{ getFixedPosSourceName(FixedPositionType::terminal, SourceIndex{ 0 }, 1) };
         auto const zTerminalPositionId{ getFixedPosSourceName(FixedPositionType::terminal, SourceIndex{ 0 }, 2) };
 
+        // position the first source
         juce::Point<float> terminalPosition;
         if (presetData->hasAttribute(xTerminalPositionId) && presetData->hasAttribute(yTerminalPositionId)) {
             juce::Point<float> const inversedNormalizedTerminalPosition{
@@ -173,6 +174,8 @@ bool PresetsManager::load(int const presetNumber)
     }
     mLastLoadedPreset = presetNumber;
 
+    // send a change message, which will end up calling SourceLinkEnforcer::enforceSourceLink()
+    // to position the secondary sources
     sendChangeMessage();
 
     return true;

--- a/Source/cg_PresetsManager.hpp
+++ b/Source/cg_PresetsManager.hpp
@@ -34,7 +34,7 @@ enum class FixedPositionType { terminal, initial };
 juce::String
     getFixedPosSourceName(FixedPositionType const fixedPositionType, SourceIndex const index, int const dimension);
 //==============================================================================
-class PresetsManager final : public juce::ChangeBroadcaster
+class PresetsManager final// : public juce::ChangeBroadcaster
 {
     //==============================================================================
     int mLastLoadedPreset{ 0 };
@@ -46,7 +46,7 @@ class PresetsManager final : public juce::ChangeBroadcaster
 public:
     //==============================================================================
     PresetsManager() = delete;
-    ~PresetsManager() noexcept override = default;
+//    ~PresetsManager() noexcept override = default;
 
     PresetsManager(PresetsManager const &) = delete;
     PresetsManager(PresetsManager &&) = delete;

--- a/Source/cg_PresetsManager.hpp
+++ b/Source/cg_PresetsManager.hpp
@@ -42,6 +42,7 @@ class PresetsManager final : public juce::ChangeBroadcaster
     Sources & mSources;
     SourceLinkEnforcer & mPositionLinkEnforcer;
     SourceLinkEnforcer & mElevationLinkEnforcer;
+    SourceId & mFirstSourceId;
 
 public:
     //==============================================================================
@@ -57,16 +58,17 @@ public:
     PresetsManager(juce::XmlElement & data,
                    Sources & sources,
                    SourceLinkEnforcer & positionLinkEnforcer,
-                   SourceLinkEnforcer & elevationLinkEnforcer);
+                   SourceLinkEnforcer & elevationLinkEnforcer,
+                   SourceId & firstSourceId);
     //==============================================================================
     [[nodiscard]] int getCurrentPreset() const;
     [[nodiscard]] std::array<bool, NUMBER_OF_POSITION_PRESETS> getSavedPresets() const;
 
+    std::optional<int> getPresetSourceId(int presetNumber);
     bool loadIfPresetChanged(int presetNumber);
     bool forceLoad(int presetNumber);
     void save(int presetNumber) const;
     [[nodiscard]] bool deletePreset(int presetNumber) const;
-    void numberOfSourcesChanged();
 
 private:
     //==============================================================================

--- a/Source/cg_PresetsManager.hpp
+++ b/Source/cg_PresetsManager.hpp
@@ -34,7 +34,7 @@ enum class FixedPositionType { terminal, initial };
 juce::String
     getFixedPosSourceName(FixedPositionType const fixedPositionType, SourceIndex const index, int const dimension);
 //==============================================================================
-class PresetsManager final// : public juce::ChangeBroadcaster
+class PresetsManager final : public juce::ChangeBroadcaster
 {
     //==============================================================================
     int mLastLoadedPreset{ 0 };
@@ -46,7 +46,7 @@ class PresetsManager final// : public juce::ChangeBroadcaster
 public:
     //==============================================================================
     PresetsManager() = delete;
-//    ~PresetsManager() noexcept override = default;
+    ~PresetsManager() noexcept override = default;
 
     PresetsManager(PresetsManager const &) = delete;
     PresetsManager(PresetsManager &&) = delete;

--- a/Source/cg_SectionPositionPresets.cpp
+++ b/Source/cg_SectionPositionPresets.cpp
@@ -74,7 +74,7 @@ void PresetButton::internalClickCallback(juce::ModifierKeys const & mods)
         setToggleState(false, juce::NotificationType::dontSendNotification);
         mLoaded = mSaved = false;
     } else if (mSaved) {
-        TextButton::internalClickCallback(mods);
+        TextButton::internalClickCallback(mods); //this will cause PresetButton::clicked() to be called right above
     }
     refresh();
 }

--- a/Source/cg_SourceSnapshot.hpp
+++ b/Source/cg_SourceSnapshot.hpp
@@ -56,7 +56,7 @@ struct SourcesSnapshots {
     SourceSnapshot & operator[](SourceIndex const index);
     int size() const { return secondaries.size() + 1; }
 
-    juce::String toString ()
+    juce::String toString () const
     {
         juce::String ret;
         ret += primary.position.toString() + ", " + primary.z.toString() + "; ";

--- a/Source/cg_SourceSnapshot.hpp
+++ b/Source/cg_SourceSnapshot.hpp
@@ -56,6 +56,15 @@ struct SourcesSnapshots {
     SourceSnapshot & operator[](SourceIndex const index);
     int size() const { return secondaries.size() + 1; }
 
+    juce::String toString ()
+    {
+        juce::String ret;
+        ret += primary.position.toString() + ", " + primary.z.toString() + "; ";
+        for (auto const & snapshot : secondaries)
+            ret += snapshot.position.toString() + ", " + snapshot.z.toString() + "; ";
+       return ret;
+    }
+
 private:
     JUCE_LEAK_DETECTOR(SourceSnapshot)
 }; // class SourcesSnapshots


### PR DESCRIPTION
Not saving source-link for now because the [manual](https://sourceforge.net/projects/spatgris3/files/SpatGRIS%203.3.7%20Manual.pdf/download) explains we're not saving those since they are automated